### PR TITLE
StudentQuiz: Behat tests could be improved

### DIFF
--- a/classes/commentarea/container.php
+++ b/classes/commentarea/container.php
@@ -504,7 +504,7 @@ class container {
      * @param array $comments
      */
     public function set_user_list($comments) {
-        global $DB;
+        global $CFG, $DB;
         $userids = [];
         foreach ($comments as $comment) {
             if (!in_array($comment->userid, $userids)) {

--- a/tests/behat/add_studentquiz.feature
+++ b/tests/behat/add_studentquiz.feature
@@ -4,33 +4,8 @@ Feature: Activities can be created
   As a teacher
   I need the creation of an activity to work
 
-  @javascript
-  Scenario: Check an Activity can be created
+  Background:
     Given the following "users" exist:
-      | username | firstname | lastname | email                |
-      | teacher1 | Terry1    | Teacher1 | teacher1@example.com |
-      | student1 | Sam1      | Student1 | student1@example.com |
-    And the following "courses" exist:
-      | fullname | shortname | category |
-      | Course 1 | C1        | 0        |
-    And the following "course enrolments" exist:
-      | user     | course | role           |
-      | teacher1 | C1     | editingteacher |
-      | student1 | C1     | student        |
-    When I log in as "teacher1"
-    And I am on "Course 1" course homepage with editing mode on
-    And I add a "StudentQuiz" to section "1" and I fill the form with:
-      | StudentQuiz Name | Test quiz name        |
-      | Description      | Test quiz description |
-    And I am on "Course 1" course homepage
-    And I follow "Test quiz name"
-    Then I should see "Create new question"
-
-  @javascript
-  Scenario: Check an Activity can be created with comment deletion period = 0.
-    # In GH Actions works only on > 38
-    Given I make sure the current Moodle branch is greater or equal "39"
-    And the following "users" exist:
       | username | firstname | lastname | email                |
       | teacher1 | Terry1    | Teacher1 | teacher1@example.com |
     And the following "courses" exist:
@@ -41,13 +16,22 @@ Feature: Activities can be created
       | teacher1 | C1     | editingteacher |
     And I log in as "teacher1"
     And I am on "Course 1" course homepage with editing mode on
-    And I add a "StudentQuiz" to section "1" and I fill the form with:
+
+  @javascript
+  Scenario: Check an Activity can be created
+    When I add a "StudentQuiz" to section "1" and I fill the form with:
+      | StudentQuiz Name | Test quiz name        |
+      | Description      | Test quiz description |
+    And I am on the "Test quiz name" "mod_studentquiz > View" page
+    Then I should see "Create new question"
+
+  @javascript
+  Scenario: Check an Activity can be created with comment deletion period = 0.
+    When I add a "StudentQuiz" to section "1" and I fill the form with:
       | StudentQuiz Name                          | Test quiz name        |
       | Description                               | Test quiz description |
       | Comment editing/deletion period (minutes) | 0                     |
-    When I am on "Course 1" course homepage
-    Then I should see "Test quiz name"
-    When I follow "Test quiz name"
+    And I am on the "Test quiz name" "mod_studentquiz > View" page
     And I navigate to "Edit settings" in current page administration
     And I expand all fieldsets
     Then the field "commentdeletionperiod" matches value "0"

--- a/tests/behat/admin_settings.feature
+++ b/tests/behat/admin_settings.feature
@@ -9,34 +9,35 @@ Feature: New activities instances setting will be inherited from Admin setting
       | fullname | shortname | category |
       | Course 1 | C1        | 0        |
 
-  @javascript
   Scenario: Check Default question types appear in Admin setting
-    Given I log in as "admin"
-    When I navigate to "Plugins > StudentQuiz" in site administration
+    When I log in as "admin"
+    And I navigate to "Plugins > StudentQuiz" in site administration
     Then I should see "Allowed question types"
-    And the field "s_studentquiz_defaultqtypes[multichoice]" matches value "1"
-    And the field "s_studentquiz_defaultqtypes[truefalse]" matches value "1"
-    And the field "s_studentquiz_defaultqtypes[shortanswer]" matches value "1"
+    And the following fields match these values:
+      | s_studentquiz_defaultqtypes[multichoice] | 1 |
+      | s_studentquiz_defaultqtypes[truefalse]   | 1 |
+      | s_studentquiz_defaultqtypes[shortanswer] | 1 |
 
   @javascript
   Scenario: Check new instance will get the default question types from Admin setting
-    Given I log in as "admin"
+    When I log in as "admin"
     And the following config values are set as admin:
       | defaultqtypes | truefalse | studentquiz |
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
+    And I am on "Course 1" course homepage with editing mode on
     And I add a "StudentQuiz" to section "1"
-    When I expand all fieldsets
-    Then the field "allowedqtypes[truefalse]" matches value "1"
-    And the field "allowedqtypes[ALL]" matches value "0"
-    And the field "allowedqtypes[multichoice]" matches value "0"
-    And the field "allowedqtypes[shortanswer]" matches value "0"
+    And I expand all fieldsets
+    Then the following fields match these values:
+      | allowedqtypes[truefalse]   | 1 |
+      | allowedqtypes[ALL]         | 0 |
+      | allowedqtypes[multichoice] | 0 |
+      | allowedqtypes[shortanswer] | 0 |
     And I press "Cancel"
     And the following config values are set as admin:
       | defaultqtypes | truefalse,multichoice | studentquiz |
     And I add a "StudentQuiz" to section "1"
     And I expand all fieldsets
-    And the field "allowedqtypes[truefalse]" matches value "1"
-    And the field "allowedqtypes[multichoice]" matches value "1"
-    And the field "allowedqtypes[ALL]" matches value "0"
-    And the field "allowedqtypes[shortanswer]" matches value "0"
+    And the following fields match these values:
+      | allowedqtypes[truefalse]   | 1 |
+      | allowedqtypes[multichoice] | 1 |
+      | allowedqtypes[ALL]         | 0 |
+      | allowedqtypes[shortanswer] | 0 |

--- a/tests/behat/aggregated_changes_import.feature
+++ b/tests/behat/aggregated_changes_import.feature
@@ -25,9 +25,7 @@ Feature: Restore of studentquizzes in moodle exports contain question answers
     And I upload "mod/studentquiz/tests/fixtures/<file>" file to "Files" filemanager
     And I press "Save changes"
     And I restore "<file>" backup into a new course using this options:
-    And I am on "<course>" course homepage
-    And I follow "<studentquiz>"
-    When I navigate to "Ranking" in current page administration
+    And I am on the "<studentquiz>" "mod_studentquiz > Ranking" page
     Then "1" row "Points for latest correct attemps" column of "rankingtable" table should contain "<pos_1_correct_answered_points>"
     And "1" row "Total Points" column of "rankingtable" table should contain "<pos_1_total_points>"
     And "2" row "Points for latest correct attemps" column of "rankingtable" table should contain "<pos_2_correct_answered_points>"

--- a/tests/behat/anonymised_instance.feature
+++ b/tests/behat/anonymised_instance.feature
@@ -8,30 +8,24 @@ Feature: StudentQuiz anonymous mode
     Given the following "users" exist:
       | username | firstname | lastname | email                |
       | student1 | Sam1      | Student1 | student1@example.com |
-      | student2 | Sam2      | Student2 | student2@example.com |
     And the following "courses" exist:
       | fullname | shortname | category |
       | Course 1 | C1        | 0        |
     And the following "course enrolments" exist:
       | user     | course | role    |
       | student1 | C1     | student |
-      | student2 | C1     | student |
 
   Scenario: Student should not see anonymised when StudentQuiz is a non-anonymous instance
-    Given the following "activities" exist:
+    And the following "activities" exist:
       | activity    | name          | intro              | course | idnumber     | anonymrank |
       | studentquiz | StudentQuiz 1 | Quiz 1 description | C1     | studentquiz1 | 0          |
-    And I log in as "student1"
-    And I am on "Course 1" course homepage
-    When I follow "StudentQuiz 1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
     Then I should see "Ranking" in the "#mod_studentquiz_rankingblock" "css_element"
     And I should not see "Ranking (anonymised)" in the "#mod_studentquiz_rankingblock" "css_element"
 
   Scenario: Student should see anonymised when StudentQuiz is a anonymous instance
-    Given the following "activities" exist:
+    And the following "activities" exist:
       | activity    | name          | intro              | course | idnumber     | anonymrank |
       | studentquiz | StudentQuiz 1 | Quiz 1 description | C1     | studentquiz1 | 1          |
-    And I log in as "student1"
-    And I am on "Course 1" course homepage
-    When I follow "StudentQuiz 1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
     Then I should see "Ranking (anonymised)" in the "#mod_studentquiz_rankingblock" "css_element"

--- a/tests/behat/behat_mod_studentquiz.php
+++ b/tests/behat/behat_mod_studentquiz.php
@@ -112,4 +112,80 @@ class behat_mod_studentquiz extends behat_base {
         $this->getSession()->executeScript($js);
     }
 
+    /**
+     * Convert page names to URLs for steps like 'When I am on the "[page name]" page'.
+     *
+     * Recognised page names are:
+     * | None so far!      |                                                              |
+     *
+     * @param string $page name of the page, with the component name removed e.g. 'Admin notification'.
+     * @return moodle_url the corresponding URL.
+     * @throws Exception with a meaningful error message if the specified page cannot be found.
+     */
+    protected function resolve_page_url(string $page): moodle_url {
+        switch ($page) {
+            default:
+                throw new Exception('Unrecognised studentquiz page type "' . $page . '."');
+        }
+    }
+
+    /**
+     * Convert page names to URLs for steps like 'When I am on the "[identifier]" "[page type]" page'.
+     *
+     * Recognised page names are:
+     * | pagetype          | name meaning                                | description                                  |
+     * | View              | Student Quiz name                           | The student quiz info page (view.php)        |
+     * | Edit              | Student Quiz name                           | The edit quiz page (edit.php)                |
+     * | Statistics        | Student Quiz name                           | The Statistics report page                   |
+     * | Ranking           | Student Quiz name                           | The Ranking page                             |
+     *
+     * @param string $type identifies which type of page this is, e.g. 'View'.
+     * @param string $identifier identifies the particular page, e.g. 'Test student quiz'.
+     * @return moodle_url the corresponding URL.
+     * @throws Exception with a meaningful error message if the specified page cannot be found.
+     */
+    protected function resolve_page_instance_url(string $type, string $identifier): moodle_url {
+        switch ($type) {
+            case 'View':
+                return new moodle_url('/mod/studentquiz/view.php',
+                                      ['id' => $this->get_cm_by_studentquiz_name($identifier)->id]);
+
+            case 'Edit':
+                return new moodle_url('/course/modedit.php',
+                                      ['update' => $this->get_cm_by_studentquiz_name($identifier)->id]);
+
+            case 'Statistics':
+                return new moodle_url('/mod/studentquiz/reportstat.php',
+                                      ['id' => $this->get_cm_by_studentquiz_name($identifier)->id]);
+
+            case 'Ranking':
+                return new moodle_url('/mod/studentquiz/reportrank.php',
+                                      ['id' => $this->get_cm_by_studentquiz_name($identifier)->id]);
+
+            default:
+                throw new Exception('Unrecognised studentquiz page type "' . $type . '."');
+        }
+    }
+
+    /**
+     * Get a studentquiz by name.
+     *
+     * @param string $name studentquiz name.
+     * @return stdClass the corresponding DB row.
+     */
+    protected function get_studentquiz_by_name(string $name): stdClass {
+        global $DB;
+        return $DB->get_record('studentquiz', array('name' => $name), '*', MUST_EXIST);
+    }
+
+    /**
+     * Get cmid from the studentquiz name.
+     *
+     * @param string $name studentquiz name.
+     * @return stdClass cm from get_coursemodule_from_instance.
+     */
+    protected function get_cm_by_studentquiz_name(string $name): stdClass {
+        $studentquiz = $this->get_studentquiz_by_name($name);
+        return get_coursemodule_from_instance('studentquiz', $studentquiz->id, $studentquiz->course);
+    }
 }

--- a/tests/behat/changes_restorable.feature
+++ b/tests/behat/changes_restorable.feature
@@ -18,21 +18,20 @@ Feature: Stable restore of moodle course backups
   @javascript
   Scenario: Backup and restore of the current course
     When I log in as "admin"
-    Then I backup "Course 1" course using this options:
+    And I backup "Course 1" course using this options:
       | Confirmation | Filename | test_backup.mbz |
     And I restore "test_backup.mbz" backup into a new course using this options:
       | Schema | Course name       | Course 2 |
       | Schema | Course short name | Course 2 |
     Then I should see "Course 2"
 
-    When I go to the courses management page
+    And I go to the courses management page
     And I click on "delete" action for "Course 1" in management course listing
     And I press "Delete"
-    Then I should see "Deleting C1"
+    And I should see "Deleting C1"
     And I should see "C1 has been completely deleted"
 
-    When I am on "Course 2" course homepage
-    And I follow "StudentQuiz 1"
-    Then I should see "Create new question"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page
+    And I should see "Create new question"
     And I should see "Test question to be copied"
     And "Start Quiz" "button" should exist

--- a/tests/behat/comment_area_create.feature
+++ b/tests/behat/comment_area_create.feature
@@ -7,7 +7,7 @@ Feature: Create comment as an user
   Background:
     # 'I set the field' doesn't work on Moodle <= 35
     Given I make sure the current Moodle branch is greater or equal "36"
-    Given the following "users" exist:
+    And the following "users" exist:
       | username | firstname | lastname | email                |
       | teacher  | The       | Teacher  | teacher1@example.com |
       | student1 | Student   | One      | student1@example.com |
@@ -39,62 +39,59 @@ Feature: Create comment as an user
 
   @javascript @_switch_window
   Scenario: Test show initital view and Expand all comment/ Collapse all comment button. Check both start quiz and preview mode
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    # Prepare comments and replies.
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     # Wait for comment area init.
     And I wait until the page is ready
     # Enter "Comment 1".
-    When I enter the text "Comment 1" into the "Add comment" editor
-    Then I press "Add comment"
+    And I enter the text "Comment 1" into the "Add comment" editor
+    And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists
-    And I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    Then I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     # Wait for different created time.
     And I wait "1" seconds
     # Enter "Comment 2"
-    When I enter the text "Comment 2" into the "Add comment" editor
-    Then I press "Add comment"
+    And I enter the text "Comment 2" into the "Add comment" editor
+    And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(2)" "css_element" exists
     And I should see "Comment 2" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
     And I wait "1" seconds
     # Enter "Comment 3"
-    When I enter the text "Comment 3" into the "Add comment" editor
-    Then I press "Add comment"
+    And I enter the text "Comment 3" into the "Add comment" editor
+    And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(3)" "css_element" exists
     And I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
     And I wait "1" seconds
     # Enter "Comment 4"
-    When I enter the text "Comment 4" into the "Add comment" editor
-    Then I press "Add comment"
+    And I enter the text "Comment 4" into the "Add comment" editor
+    And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(4)" "css_element" exists
     And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
     And I wait "1" seconds
     # Enter "Comment 5"
-    When I enter the text "Comment 5" into the "Add comment" editor
-    Then I press "Add comment"
+    And I enter the text "Comment 5" into the "Add comment" editor
+    And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(5)" "css_element" exists
     And I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
     And I wait "1" seconds
     # Enter "Comment 6"
-    When I enter the text "Comment 6" into the "Add comment" editor
+    And I enter the text "Comment 6" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(6)" "css_element" exists
     And I should see "Comment 6" in the ".studentquiz-comment-item:nth-child(6) .studentquiz-comment-text" "css_element"
-    Then I should see "Collapse all comments"
+    And I should see "Collapse all comments"
     # Click "Collapse all comments" button, page should render like initial view.
-    When I press "Collapse all comments"
+    And I press "Collapse all comments"
     And I wait until the page is ready
-    Then I should see "Expand all comments"
+    And I should see "Expand all comments"
     And I should not see "Collapse all comments"
     And I should see "5 of 6" in the ".studentquiz-comment-postcount" "css_element"
     And I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
@@ -103,9 +100,9 @@ Feature: Create comment as an user
     And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
     And I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
     # Click "Expand all comments" button, check that all comments and replies is show.
-    When I press "Expand all comments"
+    And I press "Expand all comments"
     And I wait until the page is ready
-    Then I should see "Collapse all comments"
+    And I should see "Collapse all comments"
     And I should not see "Expand all comments"
     And I should see "6 of 6" in the ".studentquiz-comment-postcount" "css_element"
     And I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
@@ -127,13 +124,12 @@ Feature: Create comment as an user
     And I should see "0" in the ".studentquiz-comment-item:nth-child(6) .studentquiz-comment-totalreply" "css_element"
     And I should see "Replies" in the ".studentquiz-comment-item:nth-child(6) .studentquiz-comment-totalreply" "css_element"
     # Check in preview.
-    When I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    Then I click on "Preview" "link" in the "Test question to be previewed" "table_row"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page
+    And I click on "Preview" "link" in the "Test question to be previewed" "table_row"
     And I switch to "questionpreview" window
     And I wait until the page is ready
     # We only show max 5 latest comments.
-    Then I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "Comment 2" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
     And I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
     And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
@@ -141,42 +137,37 @@ Feature: Create comment as an user
 
   @javascript
   Scenario: Test reply comment.
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    # Prepare comments and replies.
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     # Wait for comment area init.
     And I wait until the page is ready
-    When I enter the text "Comment 1" into the "Add comment" editor
+    And I enter the text "Comment 1" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists
     Then I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     # Check can reply
-    When I click on "Reply" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-buttons" "css_element"
+    And I click on "Reply" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-buttons" "css_element"
     # Wait for reply init.
     And I wait until the page is ready
     And I enter the text "Reply comment 1" into the "Add reply" editor
     And I press "Add reply"
     And I wait until the page is ready
-    Then I should see "1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-totalreply" "css_element"
+    And I should see "1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-totalreply" "css_element"
     And I should see "Reply" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-totalreply" "css_element"
 
   @javascript
   Scenario: Test delete comment feature.
     # Save document into course 1.
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     # Wait for comment area init.
     And I wait until the page is ready
-    Then I enter the text "Comment 1" into the "Add comment" editor
+    And I enter the text "Comment 1" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists
@@ -185,44 +176,40 @@ Feature: Create comment as an user
     And I should see "Delete" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I should see "1 of 1"
     # Try to delete comment.
-    When I click on "Delete" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
+    And I click on "Delete" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I wait until the page is ready
     And I click on "[title='Delete comment']" "css_element" in the ".modal.show" "css_element"
     And I wait until the page is ready
     # Check comment is render as deleted and global count updated.
-    Then I should see "Deleted post" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-item-outerbox" "css_element"
+    And I should see "Deleted post" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-item-outerbox" "css_element"
     And I should see "0 of 0"
 
   @javascript
   Scenario: Test force comment (as student)
     # Save document into course 1.
-    Given I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    When I press "Finish"
-    Then I should see "Please comment"
-    When I enter the text "Comment 1" into the "Add comment" editor
-    Then I press "Add comment"
+    And I press "Finish"
+    And I should see "Please comment"
+    And I enter the text "Comment 1" into the "Add comment" editor
+    And I press "Add comment"
     And I wait until the page is ready
-    When I press "Finish"
+    And I press "Finish"
     Then I should not see "Please comment"
 
   @javascript
   Scenario: Admin delete comment and check if student can view.
     # Save document into course 1.
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     # Wait for comment area init.
     And I wait until the page is ready
-    When I enter the text "Comment 1" into the "Add comment" editor
+    And I enter the text "Comment 1" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists
@@ -231,254 +218,230 @@ Feature: Create comment as an user
     And I should see "Delete" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I should see "1 of 1"
     # Try to delete comment.
-    When I click on "Delete" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
+    And I click on "Delete" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I click on "[title='Delete comment']" "css_element" in the ".modal.show" "css_element"
     And I wait until the page is ready
     # Check comment is render as deleted and global count updated.
-    Then I should see "Deleted post" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-item-outerbox" "css_element"
+    And I should see "Deleted post" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-item-outerbox" "css_element"
     And I should see "0 of 0"
     And I log out
     # Student log in and see it or not
-    Given I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
     And I should not see "Comment 1"
 
   @javascript
   Scenario: Test report comment feature.
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    # Try to report when disable report feature.
-    When I follow "StudentQuiz 1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
     And I click on "Start Quiz" "button"
     And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    When I enter the text "Comment 1" into the "Add comment" editor
+    And I enter the text "Comment 1" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists
     Then I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     # Not visible!
-    Then I should not see "Report"
+    And I should not see "Report"
     # Enable report feature.
-    When I follow "StudentQuiz 1"
-    And I navigate to "Edit settings" in current page administration
+    And I am on the "StudentQuiz 1" "mod_studentquiz > Edit" page
     And I expand all fieldsets
     # Try to input wrong format.
     And I set the field "Email for reporting offensive comments" to "admin@domain.com;"
-    When I press "Save and display"
-    Then I should see "This email address is not valid. Please enter a single email address."
-    # Then input right one.
-    When I set the field "Email for reporting offensive comments" to "admin@domain.com;admin1@domain.com"
     And I press "Save and display"
-    Then I should see "StudentQuiz 1"
+    And I should see "This email address is not valid. Please enter a single email address."
+    # Then input right one.
+    And I set the field "Email for reporting offensive comments" to "admin@domain.com;admin1@domain.com"
+    And I press "Save and display"
+    And I should see "StudentQuiz 1"
     # Try to report.
     And I click on "Start Quiz" "button"
     And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    Then I should see "Report"
+    And I should see "Report"
     # Test with Report feature.
-    When I click on "Report" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
-    Then I should see "Report a comment as unacceptable"
+    And I click on "Report" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
+    And I should see "Report a comment as unacceptable"
     And I set the field "It is abusive" to "1"
-    When I press "Send report"
-    Then I should see "Your report has been sent successfully"
-    When I press "Continue"
+    And I press "Send report"
+    And I should see "Your report has been sent successfully"
+    And I press "Continue"
     And I wait until the page is ready
     # After report, check we navigate back.
-    Then I should see "Add comment"
+    And I should see "Add comment"
 
   @javascript
   Scenario: Admin and user can sortable.
     # Student 2
-    Given I log in as "student2"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student2"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    When I enter the text "Comment 2" into the "Add comment" editor
+    And I enter the text "Comment 2" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I log out
     # Student 3
-    Given I log in as "student3"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student3"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    When I enter the text "Comment 3" into the "Add comment" editor
+    And I enter the text "Comment 3" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I log out
     # Student 4
-    Given I log in as "student4"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student4"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    When I enter the text "Comment 4" into the "Add comment" editor
+    And I enter the text "Comment 4" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I log out
     # Student 5
-    Given I log in as "student5"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student5"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    When I enter the text "Comment 5" into the "Add comment" editor
+    And I enter the text "Comment 5" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I log out
     # Student 6
-    Given I log in as "student6"
+    And I log in as "student6"
     And I am on "Course 1" course homepage
     And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    When I enter the text "Comment 6" into the "Add comment" editor
+    And I enter the text "Comment 6" into the "Add comment" editor
     And I press "Add comment"
-    When I enter the text "Comment 7" into the "Add comment" editor
+    And I enter the text "Comment 7" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I log out
     # Log in as admin
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
     # Sort Date DESC (Default is Date ASC).
-    When I click on "Date" "link" in the ".studentquiz-comment-filters" "css_element"
+    And I click on "Date" "link" in the ".studentquiz-comment-filters" "css_element"
     # Prevent behat fails (even single run is fine).
     And I wait until the page is ready
     Then I should see "Comment 7" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
-    Then I should see "Comment 6" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
-    Then I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
-    Then I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
-    Then I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 6" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
     # Sort Date ASC.
-    When I click on "Date" "link" in the ".studentquiz-comment-filters" "css_element"
+    And I click on "Date" "link" in the ".studentquiz-comment-filters" "css_element"
     And I wait until the page is ready
-    Then I should see "Comment 2" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 2" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
     And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
     And I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
     And I should see "Comment 6" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
     # Sort first name ASC.
-    When I click on "Forename" "link" in the ".studentquiz-comment-filters" "css_element"
+    And I click on "Forename" "link" in the ".studentquiz-comment-filters" "css_element"
     And I wait until the page is ready
-    Then I should see "Comment 2" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 2" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
     And I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
     And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
     And I should see "Comment 7" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
     # Sort first name DESC.
-    When I click on "Forename" "link" in the ".studentquiz-comment-filters" "css_element"
+    And I click on "Forename" "link" in the ".studentquiz-comment-filters" "css_element"
     # Prevent behat fails (even single run is fine).
     And I wait until the page is ready
-    Then I should see "Comment 7" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 7" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "Comment 6" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
     And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
     And I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
     And I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
     # Sort last name ASC.
-    When I click on "Surname" "link" in the ".studentquiz-comment-filters" "css_element"
+    And I click on "Surname" "link" in the ".studentquiz-comment-filters" "css_element"
     # Prevent behat fails (even single run is fine).
     And I wait until the page is ready
-    Then I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 5" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
     And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
     And I should see "Comment 2" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
     And I should see "Comment 7" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
     # Sort last name DESC.
-    When I click on "Surname" "link" in the ".studentquiz-comment-filters" "css_element"
+    And I click on "Surname" "link" in the ".studentquiz-comment-filters" "css_element"
     # Prevent behat fails (even single run is fine).
     And I wait until the page is ready
-    Then I should see "Comment 7" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 7" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "Comment 6" in the ".studentquiz-comment-item:nth-child(2) .studentquiz-comment-text" "css_element"
     And I should see "Comment 2" in the ".studentquiz-comment-item:nth-child(3) .studentquiz-comment-text" "css_element"
     And I should see "Comment 4" in the ".studentquiz-comment-item:nth-child(4) .studentquiz-comment-text" "css_element"
     And I should see "Comment 3" in the ".studentquiz-comment-item:nth-child(5) .studentquiz-comment-text" "css_element"
     And I log out
     # Check as student 1.
-    Given I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    Then I should see "Date" in the ".studentquiz-comment-filters" "css_element"
+    And I should see "Date" in the ".studentquiz-comment-filters" "css_element"
     And I should see "Forename" in the ".studentquiz-comment-filters" "css_element"
     And I should see "Surname" in the ".studentquiz-comment-filters" "css_element"
     # Should only see date filter.
-    When I am on "Course 1" course homepage
-    And I follow "StudentQuiz 2"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I am on the "StudentQuiz 2" "mod_studentquiz > View" page
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     And I wait until the page is ready
-    When I enter the text "Comment test user 1" into the "Add comment" editor
+    And I enter the text "Comment test user 1" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
-    Then I should see "Date" in the ".studentquiz-comment-filters" "css_element"
+    And I should see "Date" in the ".studentquiz-comment-filters" "css_element"
     And I should not see "Forename" in the ".studentquiz-comment-filters" "css_element"
     And I should not see "Surname" in the ".studentquiz-comment-filters" "css_element"
 
   @javascript
   Scenario: Test placeholder display after click Add comment.
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Start Quiz" "button"
     And I set the field "True" to "1"
     And I press "Check"
     # Wait for comment area init.
-    When I wait until the page is ready
+    And I wait until the page is ready
     # Check if placeholder has correct text.
-    Then the "data-placeholder" attribute of ".editor_atto_content_wrap" "css_element" should contain "Enter your comment here ..."
+    And the "data-placeholder" attribute of ".editor_atto_content_wrap" "css_element" should contain "Enter your comment here ..."
     # Enter "Comment 1".
-    When I enter the text "Comment 1" into the "Add comment" editor
+    And I enter the text "Comment 1" into the "Add comment" editor
     # Check data-placeholder now is empty.
     Then ".editor_atto_content_wrap[data-placeholder='']" "css_element" should exist
     And I press "Add comment"
     And I wait until the page is ready
-    When I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists
-    Then I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists
+    And I should see "Comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     # Check placeholder is back with correct text.
     And the "data-placeholder" attribute of ".editor_atto_content_wrap" "css_element" should contain "Enter your comment here ..."
 
   @javascript
   Scenario: Test edit comment/reply.
-    Given I log in as "student1"
-    And I am on "Course 1" course homepage
-    # Prepare comments and replies.
-    And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     # Wait for comment area init.
     And I wait until the page is ready
-    When I enter the text "Comment 1" into the "Add comment" editor
+    And I enter the text "Comment 1" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists
@@ -487,81 +450,79 @@ Feature: Create comment as an user
     # Check edit button.
     And I should see "Edit" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     # Try to edit.
-    When I click on "Edit" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
+    And I click on "Edit" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I wait until the page is ready
     And I enter the text "Comment 1 edited" into the "Edit comment" editor
     And I press "Save changes"
     And I wait until the page is ready
-    Then I should see "Comment 1 edited" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Comment 1 edited" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "Edited by the Author" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I click on "History" "link" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I switch to "Comment history" window
     And I wait until the page is ready
     And I should see "Comment 1 edited"
     # Read a reply.
-    When I switch to the main window
+    And I switch to the main window
     And I click on "Reply" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-buttons" "css_element"
     # Wait for reply init.
     And I wait until the page is ready
     And I enter the text "Reply comment 1" into the "Add reply" editor
     And I press "Add reply"
     And I wait until the page is ready
-    Then I should see "Reply comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Reply comment 1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "1" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-totalreply" "css_element"
     # Check edit button of reply.
     And I should see "Edit" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     # Try to edit reply.
-    When I click on "Edit" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
+    And I click on "Edit" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I wait until the page is ready
     And I enter the text "Reply comment 1 edited" into the "Edit comment" editor
     And I press "Save changes"
     And I wait until the page is ready
-    Then I should see "Reply comment 1 edited" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
+    And I should see "Reply comment 1 edited" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I should see "Edited by the Author" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I click on "History" "link" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-text" "css_element"
     And I switch to "Comment history" window
     And I wait until the page is ready
     And I should see "Reply comment 1 edited"
-    When I switch to the main window
+    And I switch to the main window
     And I log out
     # Try with student2 - should not see edit button.
-    Given I log in as "student2"
+    And I log in as "student2"
     And I am on "Course 1" course homepage
     # Prepare comments and replies.
     And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     # Wait for comment area init.
     And I wait until the page is ready
     # Expand to view all comments.
-    When I press "Expand all comments"
+    And I press "Expand all comments"
     And I wait until the page is ready
-    Then I should not see "Edit" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
+    And I should not see "Edit" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I should not see "Edit" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-replies .studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
 
   @javascript
   Scenario: Test enable/disable edit feature.
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    When I follow "StudentQuiz 1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
     And I navigate to "Edit settings" in current page administration
     And I expand all fieldsets
-    When I set the field "Comment editing/deletion period (minutes)" to "0"
+    And I set the field "Comment editing/deletion period (minutes)" to "0"
     And I press "Save and display"
-    Then I should see "StudentQuiz 1"
+    And I should see "StudentQuiz 1"
     And I log out
-    Given I log in as "student1"
+    And I log in as "student1"
     And I am on "Course 1" course homepage
     # Prepare comments and replies.
     And I follow "StudentQuiz 1"
-    When I click on "Start Quiz" "button"
-    Then I set the field "True" to "1"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
     And I press "Check"
     # Wait for comment area init.
     And I wait until the page is ready
     # Try to comment.
-    When I enter the text "Comment 1" into the "Add comment" editor
+    And I enter the text "Comment 1" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I wait until ".studentquiz-comment-item:nth-child(1)" "css_element" exists

--- a/tests/behat/installed.feature
+++ b/tests/behat/installed.feature
@@ -6,7 +6,7 @@ Feature: Installation succeeds
 
   Scenario: Check the Plugins overview for the name of this plugin
     Given I log in as "admin"
-    And I navigate to "Plugins overview" in site administration
+    When I navigate to "Plugins overview" in site administration
     Then the following should exist in the "plugins-control-panel" table:
-        |Plugin name|
-        |mod_studentquiz|
+      | Plugin name     |
+      | mod_studentquiz |

--- a/tests/behat/moodle_backup.feature
+++ b/tests/behat/moodle_backup.feature
@@ -22,13 +22,11 @@ Feature: Backup and restore of moodle exports
     And I press "Save changes"
     And I restore "<file>" backup into a new course using this options:
     And I log out
-    Then the following "course enrolments" exist:
+    And the following "course enrolments" exist:
       | user     | course   | role    |
       | student1 | <course> | student |
-    And I log in as "student1"
-    And I am on "<course>" course homepage
-    And I follow "<studentquiz>"
-    And I should see "Create new question"
+    And I am on the "<studentquiz>" "mod_studentquiz > View" page logged in as "student1"
+    Then I should see "Create new question"
     And "Start Quiz" "button" should exist
     # TODO: These backups have good data selection, we could test for existence and correctness of these
     # TODO: A scenario with the new studentquiz so other datas could be tested too

--- a/tests/behat/navigation.feature
+++ b/tests/behat/navigation.feature
@@ -20,9 +20,7 @@ Feature: Navigation to the pages
     And the following "questions" exist:
       | questioncategory          | qtype | name          | questiontext                  |
       | Default for StudentQuiz 1 | essay | Test question | Write about whatever you want |
-    And I log in as "teacher1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "teacher1"
 
   Scenario: See the main page
     When I navigate to "StudentQuiz" in current page administration
@@ -39,23 +37,23 @@ Feature: Navigation to the pages
   Scenario: See the statistics page
     When I navigate to "Statistics" in current page administration
     Then I should see "Personal Statistics"
-    Then I should see "Community Statistics"
-    Then I should see "Personal Progress"
+    And I should see "Community Statistics"
+    And I should see "Personal Progress"
 
   Scenario: See the ranking page
     When I navigate to "Ranking" in current page administration
     Then I should see "Published question factor"
-    Then I should see "Latest correct answer factor"
-    Then I should see "Total Points"
-    Then I should see "Personal progress"
+    And I should see "Latest correct answer factor"
+    And I should see "Total Points"
+    And I should see "Personal progress"
 
   Scenario: See the questionbank
     When I navigate to "Question bank" in current page administration
     Then I should see "Questions"
-    Then I should see "Categories"
-    Then I should see "Import"
-    Then I should see "Export"
-    Then I should see "Select a category:"
+    And I should see "Categories"
+    And I should see "Import"
+    And I should see "Export"
+    And I should see "Select a category:"
 
   Scenario: Check that the More link exist in My Progress and Ranking block
     When I navigate to "StudentQuiz" in current page administration

--- a/tests/behat/preview_question.feature
+++ b/tests/behat/preview_question.feature
@@ -25,10 +25,8 @@ Feature: Preview a question as a student
   # For faster processing these scenarios are concatenated, as $_switch_window seems to do a behat site reset
   @javascript @_switch_window
   Scenario: Question preview shows the question, can be answered and commented
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    When I click on "Preview" "link" in the "Test question to be previewed" "table_row"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Preview" "link" in the "Test question to be previewed" "table_row"
     And I switch to "questionpreview" window
     Then the state of "What is pi to two d.p.?" question is shown as "Not complete"
     #Then "Rate" "field" should exist
@@ -38,17 +36,17 @@ Feature: Preview a question as a student
     #And I should see "Add comment" in the ".comments p" "css_element"
     #And ".comments" "css_element" should exist
     And I should see "No comments"
-    Then I set the field "Answer:" to "3.14"
+    And I set the field "Answer:" to "3.14"
     And I press "Check"
     And I wait until the page is ready
-    Then the state of "What is pi to two d.p.?" question is shown as "Correct"
+    And the state of "What is pi to two d.p.?" question is shown as "Correct"
     And ".rateable[data-rate='4']" "css_element" should exist
     And I click on ".rateable[data-rate='4']" "css_element"
     And ".star[data-rate='4']" "css_element" should exist
     And ".star-empty[data-rate='4']" "css_element" should not exist
     And ".star[data-rate='5']" "css_element" should not exist
     And ".star-empty[data-rate='5']" "css_element" should exist
-    Then I enter the text "Very good question" into the "Add comment" editor
+    And I enter the text "Very good question" into the "Add comment" editor
     And I press "Add comment"
     And I wait until the page is ready
     And I should see "Very good question"
@@ -56,21 +54,18 @@ Feature: Preview a question as a student
     And I should see "Delete" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I should see "1 of 1"
     # Try to delete comment.
-    Then I click on "Delete" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
+    And I click on "Delete" "button" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-commands-box" "css_element"
     And I click on "[title='Delete comment']" "css_element" in the ".modal.show" "css_element"
     And I wait until the page is ready
     # Check comment is render as deleted and global count updated.
-    Then I should see "Deleted post" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-item-outerbox" "css_element"
+    And I should see "Deleted post" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-item-outerbox" "css_element"
     And I should see "0 of 0"
 
   @javascript @_switch_window
   Scenario: Student post new question, and he/she can not see comment or rating box on new's one
-    Given I log in as "student1"
-    # Log in to course 1.
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
     # Create owned question by student role.
-    When I should see "Create new question"
+    Then I should see "Create new question"
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
     And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
@@ -79,7 +74,7 @@ Feature: Preview a question as a student
     And I set the field "Question text" to "The correct answer is true"
     And I press "id_submitbutton"
     # Turn back and click to Preview link to validate role.
-    Then I click on "Preview" "link" in the "Example question 1" "table_row"
+    And I click on "Preview" "link" in the "Example question 1" "table_row"
     And I switch to "questionpreview" window
     And I should not see "Rate"
     And I should not see "Add comment"
@@ -87,22 +82,19 @@ Feature: Preview a question as a student
 
   @javascript @_switch_window
   Scenario: User with higher student's role post new question, and he/she can comment or rating on new's one
-    Given I log in as "admin"
-    # Log in to course 1.
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
     # Create owned question by student role.
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
     And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
-    And I should see "Adding a True/False question"
+    Then I should see "Adding a True/False question"
     And I set the field "Question name" to "Example question 2"
     And I set the field "Question text" to "The correct answer is true"
     And I press "id_submitbutton"
     # Turn back and click to Preview link to validate role.
-    When I click on "Preview" "link" in the "Example question 2" "table_row"
+    And I click on "Preview" "link" in the "Example question 2" "table_row"
     And I switch to "questionpreview" window
-    Then ".rate" "css_element" should exist
+    And ".rate" "css_element" should exist
     And "Add comment" "field" should exist
     And I enter the text "Comment test" into the "Add comment" editor
     And I press "Add comment"

--- a/tests/behat/question_submission_answering_phases.feature
+++ b/tests/behat/question_submission_answering_phases.feature
@@ -19,11 +19,10 @@ Feature: Question submission and answering will follow the availability setting
 
   @javascript
   Scenario: New availability settings should exist
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
+    When I log in as "admin"
+    And I am on "Course 1" course homepage with editing mode on
     And I add a "StudentQuiz" to section "1"
-    When I expand all fieldsets
+    And I expand all fieldsets
     Then I should see "Open for question submission from"
     And I should see "Closed for question submission from"
     And I should see "Open for answering from"
@@ -31,9 +30,8 @@ Feature: Question submission and answering will follow the availability setting
 
   @javascript
   Scenario: Availability settings validation
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I turn editing mode on
+    When I log in as "admin"
+    And I am on "Course 1" course homepage with editing mode on
     And I add a "StudentQuiz" to section "1"
     And I expand all fieldsets
     And I set the field "id_name" to "StudentQuiz Test Availability"
@@ -42,7 +40,7 @@ Feature: Question submission and answering will follow the availability setting
     And I set the field "id_opensubmissionfrom_enabled" to "1"
     And I set the field "id_closesubmissionfrom_enabled" to "1"
     And I set the availability field "closesubmissionfrom" to "-1" days from now
-    When I press "Save and display"
+    And I press "Save and display"
     Then I should see "Submissions deadline can not be specified before the open for submissions date"
 
     # Answering deadline can not be specified before the open for answering date
@@ -51,14 +49,11 @@ Feature: Question submission and answering will follow the availability setting
     And I set the field "id_openansweringfrom_enabled" to "1"
     And I set the field "id_closeansweringfrom_enabled" to "1"
     And I set the availability field "closeansweringfrom" to "-1" days from now
-    When I press "Save and display"
+    And I press "Save and display"
     Then I should see "Answering deadline can not be specified before the open for answering date"
 
-  @javascript
   Scenario: Availability settings for question submission
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    When I follow "StudentQuiz Test"
+    When I am on the "StudentQuiz Test" "mod_studentquiz > View" page logged in as "admin"
     Then the "Create new question" "button" should be enabled
 
     # Enable only for Open for question submission (Future)
@@ -66,16 +61,16 @@ Feature: Question submission and answering will follow the availability setting
     And I expand all fieldsets
     And I set the field "id_opensubmissionfrom_enabled" to "1"
     And I set the availability field "opensubmissionfrom" to "+5" days from now
-    When I press "Save and display"
-    Then the "Create new question" "button" should be disabled
+    And I press "Save and display"
+    And the "Create new question" "button" should be disabled
     And I should see "Open for question submission from"
 
     # Enable only for Open for question submission (Past)
     And I navigate to "Edit settings" in current page administration
     And I expand all fieldsets
     And I set the availability field "opensubmissionfrom" to "-5" days from now
-    When I press "Save and display"
-    Then the "Create new question" "button" should be enabled
+    And I press "Save and display"
+    And the "Create new question" "button" should be enabled
     And I should not see "Open for question submission from"
 
     # Enable only for Close for question submission (Past)
@@ -84,16 +79,16 @@ Feature: Question submission and answering will follow the availability setting
     And I set the field "id_opensubmissionfrom_enabled" to "0"
     And I set the field "id_closesubmissionfrom_enabled" to "1"
     And I set the availability field "closesubmissionfrom" to "-5" days from now
-    When I press "Save and display"
-    Then the "Create new question" "button" should be disabled
+    And I press "Save and display"
+    And the "Create new question" "button" should be disabled
     And I should see "This StudentQuiz closed for question submission on"
 
     # Enable only for Close for question submission (Future)
     And I navigate to "Edit settings" in current page administration
     And I expand all fieldsets
     And I set the availability field "closesubmissionfrom" to "+5" days from now
-    When I press "Save and display"
-    Then the "Create new question" "button" should be enabled
+    And I press "Save and display"
+    And the "Create new question" "button" should be enabled
     And I should see "This StudentQuiz closes for question submission on"
 
     # Enable both Open and Close for question submission (Open in the Past)
@@ -103,8 +98,8 @@ Feature: Question submission and answering will follow the availability setting
     And I set the field "id_closesubmissionfrom_enabled" to "1"
     And I set the availability field "opensubmissionfrom" to "-5" days from now
     And I set the availability field "closesubmissionfrom" to "+5" days from now
-    When I press "Save and display"
-    Then the "Create new question" "button" should be enabled
+    And I press "Save and display"
+    And the "Create new question" "button" should be enabled
     And I should see "This StudentQuiz closes for question submission on"
 
     # Enable both Open and Close for question submission (Open in the Future)
@@ -114,15 +109,12 @@ Feature: Question submission and answering will follow the availability setting
     And I set the field "id_closesubmissionfrom_enabled" to "1"
     And I set the availability field "opensubmissionfrom" to "+5" days from now
     And I set the availability field "closesubmissionfrom" to "+10" days from now
-    When I press "Save and display"
-    Then the "Create new question" "button" should be disabled
+    And I press "Save and display"
+    And the "Create new question" "button" should be disabled
     And I should see "Open for question submission from"
 
-  @javascript
   Scenario: Availability settings for question answering
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    When I follow "StudentQuiz Test"
+    When I am on the "StudentQuiz Test" "mod_studentquiz > View" page logged in as "admin"
     Then the "Start Quiz" "button" should be enabled
 
     # Enable only for Open for question answering (Future)
@@ -130,16 +122,16 @@ Feature: Question submission and answering will follow the availability setting
     And I expand all fieldsets
     And I set the field "id_openansweringfrom_enabled" to "1"
     And I set the availability field "openansweringfrom" to "+5" days from now
-    When I press "Save and display"
-    Then the "Start Quiz" "button" should be disabled
+    And I press "Save and display"
+    And the "Start Quiz" "button" should be disabled
     And I should see "Open for answering from"
 
     # Enable only for Open for question answering (Past)
     And I navigate to "Edit settings" in current page administration
     And I expand all fieldsets
     And I set the availability field "openansweringfrom" to "-5" days from now
-    When I press "Save and display"
-    Then the "Start Quiz" "button" should be enabled
+    And I press "Save and display"
+    And the "Start Quiz" "button" should be enabled
     And I should not see "Open for answering from"
 
     # Enable only for Close for question answering (Past)
@@ -148,16 +140,16 @@ Feature: Question submission and answering will follow the availability setting
     And I set the field "id_openansweringfrom_enabled" to "0"
     And I set the field "id_closeansweringfrom_enabled" to "1"
     And I set the availability field "closeansweringfrom" to "-5" days from now
-    When I press "Save and display"
-    Then the "Start Quiz" "button" should be disabled
+    And I press "Save and display"
+    And the "Start Quiz" "button" should be disabled
     And I should see "This StudentQuiz closed for answering on"
 
     # Enable only for Close for question answering (Future)
     And I navigate to "Edit settings" in current page administration
     And I expand all fieldsets
     And I set the availability field "closeansweringfrom" to "+5" days from now
-    When I press "Save and display"
-    Then the "Start Quiz" "button" should be enabled
+    And I press "Save and display"
+    And the "Start Quiz" "button" should be enabled
     And I should see "This StudentQuiz closes for answering on"
 
     # Enable both Open and Close for question answering (Open in the Past)
@@ -167,8 +159,8 @@ Feature: Question submission and answering will follow the availability setting
     And I set the field "id_closeansweringfrom_enabled" to "1"
     And I set the availability field "openansweringfrom" to "-5" days from now
     And I set the availability field "closeansweringfrom" to "+5" days from now
-    When I press "Save and display"
-    Then the "Start Quiz" "button" should be enabled
+    And I press "Save and display"
+    And the "Start Quiz" "button" should be enabled
     And I should see "This StudentQuiz closes for answering on"
 
     # Enable both Open and Close for question answering (Open in the Future)
@@ -178,6 +170,6 @@ Feature: Question submission and answering will follow the availability setting
     And I set the field "id_closeansweringfrom_enabled" to "1"
     And I set the availability field "openansweringfrom" to "+5" days from now
     And I set the availability field "closeansweringfrom" to "+10" days from now
-    When I press "Save and display"
-    Then the "Start Quiz" "button" should be disabled
+    And I press "Save and display"
+    And the "Start Quiz" "button" should be disabled
     And I should see "Open for answering from"

--- a/tests/behat/run_quiz.feature
+++ b/tests/behat/run_quiz.feature
@@ -4,7 +4,6 @@ Feature: Quizzes can be startet
   As a student
   I need the quiz run of an activity to work
 
-  @javascript
   Scenario: An already logged in user can participate a studentquiz meanwhile created
     Given the following "users" exist:
       | username | firstname | lastname | email                |
@@ -15,23 +14,21 @@ Feature: Quizzes can be startet
     And the following "course enrolments" exist:
       | user     | course | role    |
       | student1 | C1     | student |
-    Then I log in as "student1"
-    When the following "activities" exist:
+    And the following "activities" exist:
       | activity    | name          | intro              | course | idnumber     | publishnewquestion |
       | studentquiz | StudentQuiz 1 | Quiz 1 description | C1     | studentquiz1 | 1                  |
     And the following "questions" exist:
       | questioncategory          | qtype | name                       | questiontext                  |
       | Default for StudentQuiz 1 | essay | Test question to be copied | Write about whatever you want |
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    And I should see "Create new question"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    Then I should see "Create new question"
     And "Start Quiz" "button" should exist
 
   @javascript
   Scenario: A student can start a quiz on a fresh new activity and can follow the rating rules
     # 'Then I should see ... in the ".qno" "css_element"' doesn't work on Moodle <= 35
     Given I make sure the current Moodle branch is greater or equal "36"
-    Given the following "users" exist:
+    And the following "users" exist:
       | username | firstname | lastname | email                |
       | student1 | Sam1      | Student1 | student1@example.com |
     And the following "courses" exist:
@@ -43,15 +40,13 @@ Feature: Quizzes can be startet
     And the following "activities" exist:
       | activity    | name          | intro              | course | idnumber     | forcerating | publishnewquestion |
       | studentquiz | StudentQuiz 1 | Quiz 1 description | C1     | studentquiz1 | 1           | 1                  |
-    And I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
-    And I should see "Create new question"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    Then I should see "Create new question"
 
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
     And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
-    Then I should see "Adding a True/False question"
+    And I should see "Adding a True/False question"
     And I set the field "Question name" to "Exampe question 1"
     And I set the field "Question text" to "The correct answer is true"
     And I press "id_submitbutton"
@@ -59,7 +54,7 @@ Feature: Quizzes can be startet
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
     And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
-    Then I should see "Adding a True/False question"
+    And I should see "Adding a True/False question"
     And I set the field "Question name" to "Exampe question 2"
     And I set the field "Question text" to "The correct answer is true"
     And I press "id_submitbutton"
@@ -67,7 +62,7 @@ Feature: Quizzes can be startet
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
     And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
-    Then I should see "Adding a True/False question"
+    And I should see "Adding a True/False question"
     And I set the field "Question name" to "Exampe question 3"
     And I set the field "Question text" to "The correct answer is true"
     And I press "id_submitbutton"
@@ -80,7 +75,7 @@ Feature: Quizzes can be startet
     And I click on "Start Quiz" "button"
     # QUESTION 1 mainly
     #Then I should see "Can next?"
-    Then I should see "1" in the ".qno" "css_element"
+    And I should see "1" in the ".qno" "css_element"
     And I should not see "Please rate"
     # Can't navigate before answering question
     And "Previous" "button" should not exist
@@ -88,42 +83,42 @@ Feature: Quizzes can be startet
     And "Abort" "button" should exist
     And "Finish" "button" should not exist
     # Must rate before go next
-    When I set the field "True" to "1"
+    And I set the field "True" to "1"
     And I press "Check"
-    Then "Next" "button" should exist
-    When I click on "Next" "button"
-    Then I should see "Please rate"
+    And "Next" "button" should exist
+    And I click on "Next" "button"
+    And I should see "Please rate"
     # Must also rate when now trying to early abort
-    When I click on "Abort" "button"
-    Then I should see "Please rate"
-    When I click on ".rateable[data-rate='1']" "css_element"
+    And I click on "Abort" "button"
+    And I should see "Please rate"
+    And I click on ".rateable[data-rate='1']" "css_element"
     And I click on "Next" "button"
     # QUESTION 2 mainly
-    Then I should see "2" in the ".qno" "css_element"
+    And I should see "2" in the ".qno" "css_element"
     And I should not see "Please rate"
     # Can navigate back when not answered yet
     And "Previous" "button" should exist
     And "Next" "button" should not exist
     And "Abort" "button" should exist
     And "Finish" "button" should not exist
-    When I click on "Previous" "button"
-    Then I should see "1" in the ".qno" "css_element"
+    And I click on "Previous" "button"
+    And I should see "1" in the ".qno" "css_element"
     # Can navigate forth because already answered this question
     And I click on "Next" "button"
-    Then I should see "2" in the ".qno" "css_element"
+    And I should see "2" in the ".qno" "css_element"
     # After answering can only navigate back after rating
-    When I set the field "False" to "1"
+    And I set the field "False" to "1"
     And I press "Check"
     And I click on "Previous" "button"
-    Then I should see "Please rate"
-    When I click on ".rateable[data-rate='2']" "css_element"
+    And I should see "Please rate"
+    And I click on ".rateable[data-rate='2']" "css_element"
     And I click on "Previous" "button"
     #Then I should see "Can next?"
-    Then I should see "1" in the ".qno" "css_element"
+    And I should see "1" in the ".qno" "css_element"
     And I click on "Next" "button"
     And I click on "Next" "button"
     # QUESTION 3 mainly
-    Then I should see "3" in the ".qno" "css_element"
+    And I should see "3" in the ".qno" "css_element"
     And I should not see "Please rate"
     # When answered can only finish when rated
     And "Previous" "button" should exist
@@ -131,18 +126,18 @@ Feature: Quizzes can be startet
     And "Abort" "button" should exist
     And "Finish" "button" should not exist
     # After answering can only finish after rating
-    When I set the field "True" to "1"
+    And I set the field "True" to "1"
     And I press "Check"
-    Then "Previous" "button" should exist
+    And "Previous" "button" should exist
     And "Next" "button" should not exist
     And "Abort" "button" should not exist
     And "Finish" "button" should exist
-    When I click on "Finish" "button"
-    Then I should see "Please rate"
-    When I click on ".rateable[data-rate='3']" "css_element"
+    And I click on "Finish" "button"
+    And I should see "Please rate"
+    And I click on ".rateable[data-rate='3']" "css_element"
     And I click on "Finish" "button"
     # Back to main view and check the result numbers
-    Then "Create new question" "button" should exist
+    And "Create new question" "button" should exist
     And I should see "1" in the ".stat.last-attempt-correct" "css_element"
     And I should see "2" in the ".stat.last-attempt-incorrect" "css_element"
     And I should see "0" in the ".stat.never-answered" "css_element"

--- a/tests/behat/startpageview.feature
+++ b/tests/behat/startpageview.feature
@@ -22,12 +22,10 @@ Feature: View comprehensive information about this studentquiz activity
     And the following "questions" exist:
       | questioncategory          | qtype | name                       | questiontext                  |
       | Default for StudentQuiz 1 | essay | Test question to be copied | Write about whatever you want |
-    And I log in as "student1"
 
   @javascript
   Scenario: Check if the default filter settings are visible
-    When I am on "Course 1" course homepage
-    And I follow "StudentQuiz 1"
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
     And I wait until the page is ready
     Then "Filter" "fieldset" should be visible
     And I should see "Fast filter for questions"

--- a/tests/behat/state_visibility.feature
+++ b/tests/behat/state_visibility.feature
@@ -23,17 +23,14 @@ Feature: Question states and visibility
 
   @javascript
   Scenario: Test Publish new questions setting
-    Given I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 1"
+    When I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "student1"
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
     And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
     And I set the field "Question name" to "TF 01"
     And I set the field "Question text" to "The correct answer is false"
     And I press "id_submitbutton"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 2"
+    And I am on the "StudentQuiz Test 2" "mod_studentquiz > View" page
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
     And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
@@ -41,27 +38,19 @@ Feature: Question states and visibility
     And I set the field "Question text" to "The correct answer is false"
     And I press "id_submitbutton"
     And I log out
-    And I log in as "student2"
-    And I am on "Course 1" course homepage
-    When I follow "StudentQuiz Test 1"
+    And I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "student2"
     Then I should not see "TF 01"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 2"
+    And I am on the "StudentQuiz Test 2" "mod_studentquiz > View" page
     And I should see "TF 01"
     And I log out
-    And I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 1"
+    And I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "admin"
     And I should see "TF 01"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 2"
+    And I am on the "StudentQuiz Test 2" "mod_studentquiz > View" page
     And I should see "TF 01"
 
   @javascript @_switch_window
   Scenario: Test filter
-    Given I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 2"
+    When I am on the "StudentQuiz Test 2" "mod_studentquiz > View" page logged in as "student1"
 
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
@@ -92,9 +81,7 @@ Feature: Question states and visibility
     And I press "id_submitbutton"
 
     And I log out
-    And I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 2"
+    And I am on the "StudentQuiz Test 2" "mod_studentquiz > View" page logged in as "admin"
 
     And I click on "Preview" "link" in the "TF 01" "table_row"
     And I switch to "questionpreview" window
@@ -115,7 +102,7 @@ Feature: Question states and visibility
     And I switch to the main window
 
     And I click on "//a[text() = 'New']" "xpath_element"
-    When I press "id_submitbutton"
+    And I press "id_submitbutton"
     Then I should see "TF 04"
     And I should not see "TF 01"
     And I should not see "TF 02"
@@ -148,9 +135,7 @@ Feature: Question states and visibility
 
   @javascript
   Scenario: Hide question
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 1"
+    When I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "admin"
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
     And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
@@ -158,27 +143,19 @@ Feature: Question states and visibility
     And I set the field "Question text" to "The correct answer is false"
     And I press "id_submitbutton"
     And I log out
-    And I log in as "student1"
-    And I am on "Course 1" course homepage
-    When I follow "StudentQuiz Test 1"
+    And I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "student1"
     Then I should not see "TF 01"
     And I log out
-    And I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 1"
+    And I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "admin"
     And I click on "Show" "link" in the "TF 01" "table_row"
     And I log out
-    And I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 1"
+    And I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "student1"
     And I should see "TF 01"
     And "Hide" "link" should not exist in the "TF 01" "table_row"
 
   @javascript @_switch_window
   Scenario: Test Studentquiz cannot edit approved/disapproved question
-    Given I log in as "student1"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 2"
+    When I am on the "StudentQuiz Test 2" "mod_studentquiz > View" page logged in as "student1"
 
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
@@ -194,13 +171,11 @@ Feature: Question states and visibility
     And I set the field "Question text" to "The correct answer is false"
     And I press "id_submitbutton"
 
-    And "Edit" "link" should exist in the "TF 01" "table_row"
+    Then "Edit" "link" should exist in the "TF 01" "table_row"
     And "Edit" "link" should exist in the "TF 02" "table_row"
 
     And I log out
-    Given I log in as "admin"
-    And I am on "Course 1" course homepage
-    And I follow "StudentQuiz Test 2"
+    And I am on the "StudentQuiz Test 2" "mod_studentquiz > View" page logged in as "admin"
     And I click on "Preview" "link" in the "TF 01" "table_row"
     And I switch to "questionpreview" window
     And I set the field "statetype" to "Approved"
@@ -214,9 +189,7 @@ Feature: Question states and visibility
     And I switch to the main window
 
     And I log out
-    And I log in as "student1"
-    And I am on "Course 1" course homepage
-    When I follow "StudentQuiz Test 2"
+    And I am on the "StudentQuiz Test 2" "mod_studentquiz > View" page logged in as "student1"
 
     And "Edit" "link" should not exist in the "TF 01" "table_row"
     And "Edit" "link" should not exist in the "TF 02" "table_row"

--- a/tests/behat/state_visibility_old_backup_import.feature
+++ b/tests/behat/state_visibility_old_backup_import.feature
@@ -13,13 +13,12 @@ Feature: Restore of studentquizzes in moodle exports contain old approved column
 
   @javascript @_file_upload
   Scenario: Restore moodle backups containing old StudentQuiz activity with old approved column
-    Given I am on "Course 1" course homepage
+    When I am on "Course 1" course homepage
     And I navigate to "Restore" in current page administration
     And I press "Manage backup files"
     And I upload "mod/studentquiz/tests/fixtures/backup-moodle2-aggregated-before.mbz" file to "Files" filemanager
     And I press "Save changes"
     And I restore "backup-moodle2-aggregated-before.mbz" backup into a new course using this options:
-    And I am on "aggregated before" course homepage
-    When I follow "SQbefore"
+    And I am on the "SQbefore" "mod_studentquiz > View" page
     Then I should see "first"
     And I should see "second"


### PR DESCRIPTION
The summary of my working:

1. I tried to remove as much as possible the @javascript tag
2. I tried to correct the 'Give' 'When' 'Then' statement in each scenario
3. I defined the step: I am on the "]StudentQuizName]" "mod_studentquiz > [Pagetype]" page for student quiz
4. I have fixed the deprecated function get_all_user_name_fields() 
5. I tried to remove duplicated code to move them to the Background if it is possible
6. The step "I add a "activity" to section "sectionnumber" and I fill the form with:" has been changed recently. It need @javascript tag to run.

In the near future, I will continue to improve the behat tests for comments. There are many "waiting" step that shouldn't include into the test case, but the js implement is not working correctly (The js_pending isn't used in all case that it should be).