### PR TITLE
Align "With selected:" within the modulespecificbuttonscontainer element

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -1150,7 +1150,7 @@ EOT;
         $canmoveall = has_capability('mod/studentquiz:organize', $catcontext);
 
         $output .= html_writer::start_div('modulespecificbuttonscontainer');
-        $output .= html_writer::tag('strong', '&nbsp;' . get_string('withselected', 'question') . ':');
+        $output .= html_writer::tag('strong', get_string('withselected', 'question') . ':');
         $output .= html_writer::empty_tag('br');
 
         $studentquiz = mod_studentquiz_load_studentquiz($this->page->url->get_param('cmid'), $this->page->context->id);


### PR DESCRIPTION
The whole modulespecificbuttonscontainer could be revisited on its own.
But this tiny improvement deletes the superfluous space which let the label un-align with the underneath button and info.

<img width="454" alt="grafik" src="https://user-images.githubusercontent.com/377279/136656615-5e554ffd-c843-4abb-8b85-d19d28ebf79c.png">
