### PR TITLE
Add anotate_ids for statehistory backup stebslib

### DIFF
--- a/backup/moodle2/backup_studentquiz_stepslib.php
+++ b/backup/moodle2/backup_studentquiz_stepslib.php
@@ -197,6 +197,8 @@ class backup_studentquiz_activity_structure_step extends backup_questions_activi
         $comment->annotate_ids('user', 'usermodified');
         $commenthistory->annotate_ids('user', 'userid');
         $notification->annotate_ids('studentquiz', 'studentquizid');
+        $statehistory->annotate_ids('user', 'userid');
+        $statehistory->annotate_ids('question', 'questionid');
 
         // Define file annotations (we do not use itemid in this example).
         $studentquiz->annotate_files('mod_studentquiz', 'intro', null);


### PR DESCRIPTION
We are missing annotation for userid and questionid. If we backup an studentquiz and restore, then we preview the question and view the state history, sometime it will throw an error
![Screen Shot 2021-11-08 at 4 36 10 PM](https://user-images.githubusercontent.com/1708403/140718432-c0ee8f1c-1cc3-43d2-b347-1106ed4f3660.png)


