### PR TITLE
Disable buttons when there are no selected questions

### DIFF
--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -225,6 +225,7 @@ $string['no_mylastattempt_label'] = 'The question is not attempted';
 $string['no_questions_add'] = 'There are no questions in this StudentQuiz. Feel free to add some questions.';
 $string['no_questions_filter'] = 'None of the questions matched your filter criteria. Reset the filter to see all.';
 $string['no_questions_selected_message'] = 'Please select at least one question to start the quiz.';
+$string['noquestionsselectedtodoaction'] = 'Please select one or more questions before selecting this action.';
 $string['no_rates'] = 'n.a.';
 $string['no_tags'] = 'n.a.';
 $string['nofurtherprivatecomments'] = 'No further private comments are allowed once a question is \'Approved\'';

--- a/renderer.php
+++ b/renderer.php
@@ -1214,14 +1214,17 @@ EOT;
 
         if ($hasquestionincategory) {
             $params = [
-                    'class' => 'btn btn-primary form-submit',
-                    'type' => 'submit',
-                    'name' => 'startquiz',
-                    'value' => get_string('start_quiz_button', 'studentquiz')
+                'class' => 'btn btn-primary form-submit',
+                'type' => 'submit',
+                'name' => 'startquiz',
+                'value' => get_string('start_quiz_button', 'studentquiz'),
+                'disabled' => true
             ];
 
-            if (!$answeringallow) {
-                $params['disabled'] = 'disabled';
+            if ($answeringallow) {
+                $params['data-action'] = 'toggle';
+                $params['data-togglegroup'] = 'qbank';
+                $params['data-toggle'] = 'action';
             }
 
             $output .= html_writer::empty_tag('input', $params);
@@ -1229,25 +1232,37 @@ EOT;
 
         if ($caneditall) {
             $output .= html_writer::empty_tag('input', [
-                    'class' => 'btn btn-secondary',
-                    'type' => 'submit',
-                    'name' => 'approveselected',
-                    'value' => get_string('state_toggle', 'studentquiz')
+                'class' => 'btn btn-secondary',
+                'type' => 'submit',
+                'name' => 'approveselected',
+                'value' => get_string('state_toggle', 'studentquiz'),
+                'data-action' => 'toggle',
+                'data-togglegroup' => 'qbank',
+                'data-toggle' => 'action',
+                'disabled' => true
             ]);
             $output .= html_writer::empty_tag('input', [
-                    'class' => 'btn btn-secondary',
-                    'type' => 'submit',
-                    'name' => 'deleteselected',
-                    'value' => get_string('delete')
+                'class' => 'btn btn-secondary',
+                'type' => 'submit',
+                'name' => 'deleteselected',
+                'value' => get_string('delete'),
+                'data-action' => 'toggle',
+                'data-togglegroup' => 'qbank',
+                'data-toggle' => 'action',
+                'disabled' => true,
             ]);
         }
 
         if ($canmoveall) {
             $output .= html_writer::empty_tag('input', [
-                    'class' => 'btn btn-secondary',
-                    'type' => 'submit',
-                    'name' => 'move',
-                    'value' => get_string('moveto', 'question')
+                'class' => 'btn btn-secondary',
+                'type' => 'submit',
+                'name' => 'move',
+                'value' => get_string('moveto', 'question'),
+                'data-action' => 'toggle',
+                'data-togglegroup' => 'qbank',
+                'data-toggle' => 'action',
+                'disabled' => true,
             ]);
             ob_start();
             question_category_select_menu($addcontexts, false, 0, "{$category->id},{$category->contextid}");

--- a/tests/behat/question_submission_answering_phases.feature
+++ b/tests/behat/question_submission_answering_phases.feature
@@ -113,6 +113,7 @@ Feature: Question submission and answering will follow the availability setting
     And the "Create new question" "button" should be disabled
     And I should see "Open for question submission from"
 
+  @javascript
   Scenario: Availability settings for question answering
     When I am on the "StudentQuiz Test" "mod_studentquiz > View" page logged in as "admin"
     Then the "Start Quiz" "button" should be enabled

--- a/view.php
+++ b/view.php
@@ -77,6 +77,18 @@ $renderer->init_question_table_wanted_columns();
 // Load view.
 $view = new mod_studentquiz_view($course, $context, $cm, $studentquiz, $USER->id, $report);
 
+// Redirect to overview if there are no selected questions.
+if ((optional_param('approveselected', false, PARAM_BOOL) || optional_param('deleteselected', false, PARAM_BOOL)) &&
+        !optional_param('confirm', '', PARAM_ALPHANUM) ||
+        optional_param('move', false, PARAM_BOOL)) {
+    if (!mod_studentquiz_helper_get_ids_by_raw_submit($_REQUEST)) {
+        $baseurl = $view->get_questionbank()->base_url();
+        $baseurl->remove_params('deleteselected', 'approveselected', 'move');
+        redirect($baseurl, get_string('noquestionsselectedtodoaction', 'studentquiz'),
+            null, \core\output\notification::NOTIFY_WARNING);
+    }
+}
+
 // Since this page has 2 forms interacting with each other, all params must be passed in GET, thus
 // $PAGE->url will be as it has recieved the request.
 $PAGE->set_url($view->get_pageurl());


### PR DESCRIPTION
In this commit, I have fix some issues:
1. Disable all action buttons when no questions are selected.
2. In case people cheat by typing directly in the url, I have added the code to redirect after remove the action from the parameters if:
- We enter the change sate confirmation screen or delete confirmation screen without any selected question.
- We move to category without any selected question
3. In the behat tests, I have added @javascript to make sure the js code to click on the "check all" button will be called before we check the disable attribute of buttons.

Hi @timhunt,

could you please help me to review it?

Thanks.