### PR TITLE
Fix inconsistency division in columns

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -503,7 +503,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
                 $privatecontext['numberofcomments'] = get_string('no_comment', 'studentquiz');
             }
 
-            $privatecomment = '&nbsp;' . $this->render_from_template('mod_studentquiz/questionbank_comment_badge',
+            $privatecomment = '&nbsp;|&nbsp;' . $this->render_from_template('mod_studentquiz/questionbank_comment_badge',
                 $privatecontext);
         }
 


### PR DESCRIPTION
We use a pipe ( | ) divider in "My attempts" to differentiate between the two data, so we should possibly do the same for "Comments".
![Screen Shot 2021-11-19 at 2 01 45 PM](https://user-images.githubusercontent.com/1708403/142588976-0a3903b1-8af2-4f7e-ad8c-6a1d1cfc1518.png)


