### PR TITLE
Add indices to speed up privacy requests

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -124,6 +124,9 @@
         <KEY NAME="commentid" TYPE="foreign" FIELDS="commentid" REFTABLE="studentquiz_comment" REFFIELDS="id"/>
         <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+      </INDEXES>
     </TABLE>
     <TABLE NAME="studentquiz_question" COMMENT="Store question related properties">
       <FIELDS>
@@ -156,6 +159,9 @@
         <KEY NAME="questionusageid" TYPE="foreign" FIELDS="questionusageid" REFTABLE="question_usages" REFFIELDS="id"/>
         <KEY NAME="categoryid" TYPE="foreign" FIELDS="categoryid" REFTABLE="question_categories" REFFIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+      </INDEXES>
     </TABLE>
     <TABLE NAME="studentquiz_notification" COMMENT="Notification queue">
       <FIELDS>
@@ -171,6 +177,9 @@
         <KEY NAME="studentquizid" TYPE="foreign" FIELDS="studentquizid" REFTABLE="studentquiz" REFFIELDS="id"/>
         <KEY NAME="recipientid" TYPE="foreign" FIELDS="recipientid" REFTABLE="user" REFFIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="recipientid" UNIQUE="false" FIELDS="recipientid"/>
+      </INDEXES>
     </TABLE>
     <TABLE NAME="studentquiz_state_history" COMMENT="Store the history of question's states.">
       <FIELDS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -944,6 +944,38 @@ function xmldb_studentquiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2021102502, 'studentquiz');
     }
 
+    if ($oldversion < 2021112400) {
+        // Define index userid (not unique) to be added to studentquiz_comment_history.
+        $table = new xmldb_table('studentquiz_comment_history');
+        $index = new xmldb_index('userid', XMLDB_INDEX_NOTUNIQUE, ['userid']);
+
+        // Add index to studentquiz_comment_history field.
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        // Define index userid (not unique) to be added to studentquiz_attempt.
+        $table = new xmldb_table('studentquiz_attempt');
+        $index = new xmldb_index('userid', XMLDB_INDEX_NOTUNIQUE, ['userid']);
+
+        // Add index to studentquiz_attempt field.
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        // Define index recipientid (not unique) to be added to studentquiz_notification.
+        $table = new xmldb_table('studentquiz_notification');
+        $index = new xmldb_index('recipientid', XMLDB_INDEX_NOTUNIQUE, ['recipientid']);
+
+        // Add index to studentquiz_notification field.
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        // Studentquiz savepoint reached.
+        upgrade_mod_savepoint(true, 2021112400, 'studentquiz');
+    }
+
     return true;
 }
 

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component    = 'mod_studentquiz';
-$plugin->version      = 2021102502;
+$plugin->version      = 2021112400;
 $plugin->release      = 'v4.5.0';
 $plugin->requires     = 2019111800; // Version MOODLE_38, 3.8.0+.
 $plugin->maturity     = MATURITY_STABLE;


### PR DESCRIPTION
This speeds up privacy requests that fetch data about a user. Those are currently taking forever in our production system due to studentquiz.