### PR TITLE
Fix CI issues

### DIFF
--- a/backup/moodle2/backup_studentquiz_stepslib.php
+++ b/backup/moodle2/backup_studentquiz_stepslib.php
@@ -15,17 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Define all the backup steps that will be used by the backup_studentquiz_activity_structure_step
- *
- * @package   mod_studentquiz
- * @category  backup
- * @copyright 2017 HSR (http://www.hsr.ch)
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die;
-
-/**
  * Define the complete StudentQuiz structure for backup, with file and id annotations
  *
  * @package   mod_studentquiz

--- a/backup/moodle2/restore_studentquiz_stepslib.php
+++ b/backup/moodle2/restore_studentquiz_stepslib.php
@@ -13,20 +13,8 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-
-/**
- * Define all the restore steps that will be used by the restore_studentquiz_activity_structure_step
- *
- * @package   mod_studentquiz
- * @category  backup
- * @copyright 2017 HSR (http://www.hsr.ch)
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 use mod_studentquiz\local\studentquiz_helper;
 use mod_studentquiz\utils;
-
-defined('MOODLE_INTERNAL') || die;
 
 /**
  * Structure step to restore one StudentQuiz activity

--- a/classes/commentarea/comment.php
+++ b/classes/commentarea/comment.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Comment for comment area.
- *
- * @package mod_studentquiz
- * @copyright 2020 The Open University
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\commentarea;
-
-defined('MOODLE_INTERNAL') || die();
 
 use mod_studentquiz\utils;
 use moodle_url;

--- a/classes/commentarea/container.php
+++ b/classes/commentarea/container.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Container class for comment area.
- *
- * @package mod_studentquiz
- * @copyright 2020 The Open University
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\commentarea;
-
-defined('MOODLE_INTERNAL') || die();
 
 use mod_studentquiz\utils;
 use stdClass;

--- a/classes/commentarea/form/comment_simple_editor.php
+++ b/classes/commentarea/form/comment_simple_editor.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Hacky form for a simple editor with custom option.
- *
- * @package mod_studentquiz
- * @copyright 2020 The Open University
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\commentarea\form;
-
-defined('MOODLE_INTERNAL') || die;
 
 use MoodleQuickForm_editor;
 

--- a/classes/event/course_module_instance_list_viewed.php
+++ b/classes/event/course_module_instance_list_viewed.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * The mod_studentquiz instance list viewed event.
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\event;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * The mod_studentquiz instance list viewed event class.

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Defines the view event.
- *
- * @package    mod_studentquiz
- * @copyright   2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\event;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * The mod_studentquiz instance viewed event class

--- a/classes/event/studentquiz_digest_changed.php
+++ b/classes/event/studentquiz_digest_changed.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * The mod_studentquiz digest changed event
- *
- * @package    mod_studentquiz
- * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\event;
-
-defined('MOODLE_INTERNAL') || die();
 
 use mod_studentquiz\utils;
 use moodle_url;

--- a/classes/event/studentquiz_question_comment_created.php
+++ b/classes/event/studentquiz_question_comment_created.php
@@ -14,19 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_studentquiz\event;
+
 /**
  * The mod_studentquiz comment created event.
  *
  * @package    mod_studentquiz
  * @copyright  2017 HSR
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-namespace mod_studentquiz\event;
-defined('MOODLE_INTERNAL') || die();
-
-/**
- * The mod_studentquiz comment created event
  */
 class comment_created extends \core\event\comment_created {
 

--- a/classes/event/studentquiz_questionbank_viewed.php
+++ b/classes/event/studentquiz_questionbank_viewed.php
@@ -14,18 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * The mod_studentquiz report quiz viewed event
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\event;
-
-defined('MOODLE_INTERNAL') || die();
-
 
 /**
  * The mod_studentquiz report quiz viewed event

--- a/classes/event/studentquiz_report_quiz_viewed.php
+++ b/classes/event/studentquiz_report_quiz_viewed.php
@@ -14,18 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * The mod_studentquiz report quiz viewed event
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\event;
-
-defined('MOODLE_INTERNAL') || die();
-
 
 /**
  * The mod_studentquiz report quiz viewed event

--- a/classes/event/studentquiz_report_rank_viewed.php
+++ b/classes/event/studentquiz_report_rank_viewed.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * The mod_studentquiz report rank viewed event
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\event;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * The mod_studentquiz report rank viewed event

--- a/classes/local/db.php
+++ b/classes/local/db.php
@@ -14,20 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_studentquiz\local;
+
 /**
- * Helper class for StudentQuiz
+ * Additional DB abstraction toolset.
  *
  * @package mod_studentquiz
  * @copyright 2020 HSR (http://www.hsr.ch)
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-namespace mod_studentquiz\local;
-
-defined('MOODLE_INTERNAL') || die();
-
-/**
- * Additional DB abstraction toolset.
  */
 class db {
 

--- a/classes/local/studentquiz_helper.php
+++ b/classes/local/studentquiz_helper.php
@@ -14,18 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Helper class for StudentQuiz
- *
- * @package mod_studentquiz
- * @author Huong Nguyen <huongnv13@gmail.com>
- * @copyright 2019 HSR (http://www.hsr.ch)
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\local;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Helper class for StudentQuiz

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -14,19 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Event observers supported by this module
- *
- * @package mod_studentquiz
- * @copyright 2019 Huong Nguyen <huongnv13@gmail.com>
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 use mod_studentquiz\event\studentquiz_digest_changed;
 use mod_studentquiz\utils;
 use mod_studentquiz\access\context_override;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Event observers supported by this module

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -39,8 +39,7 @@ use mod_studentquiz\commentarea\container;
 use mod_studentquiz\local\studentquiz_helper;
 use mod_studentquiz\utils;
 
-interface studentquiz_userlist extends \core_privacy\local\request\core_userlist_provider
-{
+interface studentquiz_userlist extends \core_privacy\local\request\core_userlist_provider {
 }
 
 require_once($CFG->libdir . '/questionlib.php');

--- a/classes/question/bank/anonym_creator_name_column.php
+++ b/classes/question/bank/anonym_creator_name_column.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Representing anonym creator column
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * A column type for the name of the question creator.

--- a/classes/question/bank/attempts_column.php
+++ b/classes/question/bank/attempts_column.php
@@ -14,21 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Representing performances column
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Represent performances column in studentquiz_bank_view
  *
+ * @package    mod_studentquiz
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/classes/question/bank/comments_column.php
+++ b/classes/question/bank/comments_column.php
@@ -14,23 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Representing comments column
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
 
 use mod_studentquiz\utils;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Represent comments column in studentquiz_bank_view
  *
+ * @package    mod_studentquiz
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/classes/question/bank/difficulty_level_column.php
+++ b/classes/question/bank/difficulty_level_column.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Representing difficulty level column
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Representing difficulty level column in studentquiz_bank_view

--- a/classes/question/bank/preview_column.php
+++ b/classes/question/bank/preview_column.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Representing the preview column
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * A column type for preview link to mod_studentquiz_preview

--- a/classes/question/bank/question_name_column.php
+++ b/classes/question/bank/question_name_column.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Representing the question name column
- *
- * @package    mod_studentquiz
- * @copyright  2018 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * A column type for the name of the question name.

--- a/classes/question/bank/question_text_row.php
+++ b/classes/question/bank/question_text_row.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * The question bank question text row
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * A column type for the name of the question name.

--- a/classes/question/bank/rate_column.php
+++ b/classes/question/bank/rate_column.php
@@ -14,21 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Representing rating column
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Represent rate column in studentquiz_bank_view
  *
+ * @package    mod_studentquiz
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/classes/question/bank/sq_edit_action_column.php
+++ b/classes/question/bank/sq_edit_action_column.php
@@ -14,25 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Represent edit action in studentquiz_bank_view
- *
- * @package mod_studentquiz
- * @author Huong Nguyen <huongnv13@gmail.com>
- * @copyright 2019 HSR (http://www.hsr.ch)
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
 
 use core_question\bank\edit_action_column;
 use mod_studentquiz\local\studentquiz_helper;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Represent edit action in studentquiz_bank_view
  *
+ * @package mod_studentquiz
  * @author Huong Nguyen <huongnv13@gmail.com>
  * @copyright 2019 HSR (http://www.hsr.ch)
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later

--- a/classes/question/bank/sq_edit_menu_column.php
+++ b/classes/question/bank/sq_edit_menu_column.php
@@ -18,8 +18,6 @@ namespace mod_studentquiz\bank;
 
 use core_question\bank\edit_menu_column;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Represent edit column in studentquiz_bank_view which gathers together all the actions into a menu.
  *

--- a/classes/question/bank/sq_hidden_action_column.php
+++ b/classes/question/bank/sq_hidden_action_column.php
@@ -14,24 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Represent sq_hiden action in studentquiz_bank_view
- *
- * @package mod_studentquiz
- * @author Huong Nguyen <huongnv13@gmail.com>
- * @copyright 2019 HSR (http://www.hsr.ch)
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
 
 use core_question\bank\menu_action_column_base;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Represent sq_hiden action in studentquiz_bank_view
  *
+ * @package mod_studentquiz
  * @author Huong Nguyen <huongnv13@gmail.com>
  * @copyright 2019 HSR (http://www.hsr.ch)
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later

--- a/classes/question/bank/state_column.php
+++ b/classes/question/bank/state_column.php
@@ -14,21 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Representing approved column
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\bank;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Represent state column in studentquiz_bank_view
  *
+ * @package mod_studentquiz
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/classes/question/bank/studentquiz_column_base.php
+++ b/classes/question/bank/studentquiz_column_base.php
@@ -16,8 +16,6 @@
 
 namespace mod_studentquiz\bank;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Represent studentquiz column base in studentquiz_bank_view
  *

--- a/classes/task/delete_orphaned_questions.php
+++ b/classes/task/delete_orphaned_questions.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * A scheduled task for sending digest notification.
- *
- * @package    mod_studentquiz
- * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\task;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * A scheduled task for sending digest notification.

--- a/classes/task/send_digest_notification_task.php
+++ b/classes/task/send_digest_notification_task.php
@@ -14,20 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * A scheduled task for sending digest notification.
- *
- * @package    mod_studentquiz
- * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\task;
 
 use core\message\message;
 use moodle_url;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * A scheduled task for sending digest notification.

--- a/classes/task/send_no_digest_notification_task.php
+++ b/classes/task/send_no_digest_notification_task.php
@@ -14,19 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * An adhoc task for sending no digest notification.
- *
- * @package    mod_studentquiz
- * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz\task;
 
 use core\message\message;
-
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * An adhoc task for sending no digest notification.

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Class that holds utility functions used by mod_studentquiz.
- *
- * @package mod_studentquiz
- * @copyright 2020 The Open University
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
 namespace mod_studentquiz;
-
-defined('MOODLE_INTERNAL') || die();
 
 use core\dml\sql_join;
 use core_courseformat\output\local\state\cm;

--- a/db/install.php
+++ b/db/install.php
@@ -25,8 +25,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Post installation procedure
  *

--- a/tests/add_test.php
+++ b/tests/add_test.php
@@ -14,15 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for studentquiz add new instance.
- *
- * @package    mod_studentquiz
- * @copyright  2020 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die('Direct Access is forbidden!');
+namespace mod_studentquiz;
 
 use mod_studentquiz\commentarea\container;
 
@@ -33,9 +25,9 @@ use mod_studentquiz\commentarea\container;
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_add_testcase extends advanced_testcase {
+class add_test extends \advanced_testcase {
 
-    /** @var stdClass - Course. */
+    /** @var \stdClass - Course. */
     protected $course;
 
     /**
@@ -87,7 +79,7 @@ class mod_studentquiz_add_testcase extends advanced_testcase {
      * Create new studentquiz.
      *
      * @param int $period
-     * @return stdClass
+     * @return \stdClass
      */
     private function create_studentquiz($period) {
         $course = $this->course;

--- a/tests/bank_performance_test.php
+++ b/tests/bank_performance_test.php
@@ -14,13 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for the question bank query performance.
- *
- * @package    mod_studentquiz
- * @copyright  2020 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_studentquiz;
+
+use mod_studentquiz\question\bank\studentquiz_bank_view;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -52,7 +48,7 @@ require_once($CFG->dirroot . '/question/editlib.php');
  * @copyright  2020 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_bank_performance_test extends advanced_testcase {
+class bank_performance_test extends \advanced_testcase {
     /**
      * @var question generator
      */
@@ -64,7 +60,6 @@ class mod_studentquiz_bank_performance_test extends advanced_testcase {
 
     /**
      * Setup testing scenario
-     * @throws coding_exception
      */
     protected function setUp(): void {
         $this->questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
@@ -75,9 +70,8 @@ class mod_studentquiz_bank_performance_test extends advanced_testcase {
      * Run questionbank.
      *
      * @param array $result with the last studentquiz and its relations
-     * @return \mod_studentquiz\question\bank\studentquiz_bank_view
-     * @throws mod_studentquiz_view_exception
-     * @throws moodle_exception
+     * @return studentquiz_bank_view
+     * @throws \moodle_exception
      */
     public function run_questionbank($result) {
         global $PAGE;
@@ -92,8 +86,8 @@ class mod_studentquiz_bank_performance_test extends advanced_testcase {
         );
 
         $report = new mod_studentquiz_report($result['cm']->id);
-        $questionbank = new \mod_studentquiz\question\bank\studentquiz_bank_view(
-            new question_edit_contexts(context_module::instance($result['cm']->id)),
+        $questionbank = new studentquiz_bank_view(
+            new question_edit_contexts(\context_module::instance($result['cm']->id)),
             new moodle_url('/mod/studentquiz/view.php', array('cmid' => $result['cm']->id)),
             $result['course'], $result['cm'], $result['studentquiz'], $pagevars, $report);
         return $questionbank;
@@ -124,7 +118,7 @@ class mod_studentquiz_bank_performance_test extends advanced_testcase {
             // Get the question category for that studentquiz context.
             $cm = get_coursemodule_from_instance('studentquiz', $studentquiz->id);
             $result['cm'] = $cm;
-            $ctx = context_module::instance($cm->id);
+            $ctx = \context_module::instance($cm->id);
             $result['ctx'] = $ctx;
             $cat = question_get_default_category($ctx->id);
             $result['cat'] = $cat;
@@ -213,7 +207,7 @@ class mod_studentquiz_bank_performance_test extends advanced_testcase {
 
     /**
      * Display question bank
-     * @param mod_studentquiz\question\bank\studentquiz_bank_view $questionbank
+     * @param studentquiz_bank_view $questionbank
      * @param array $result with the last studentquiz and its relations
      * @param int $qpage
      * @param int $qperpage

--- a/tests/bank_view_test.php
+++ b/tests/bank_view_test.php
@@ -14,13 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for (some of) mod/studentquiz/viewlib.php.
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_studentquiz;
+
+use mod_studentquiz\question\bank\studentquiz_bank_view;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -64,7 +60,7 @@ const QUESTION_DEFAULT_NAME = 'Question';
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_bank_view_test extends advanced_testcase {
+class bank_view_test extends \advanced_testcase {
     /**
      * @var course module
      */
@@ -97,13 +93,13 @@ class mod_studentquiz_bank_view_test extends advanced_testcase {
     /**
      * Run questionbank.
      *
-     * @return \mod_studentquiz\question\bank\studentquiz_bank_view
-     * @throws mod_studentquiz_view_exception
-     * @throws moodle_exception
+     * @return studentquiz_bank_view
+     * @throws \mod_studentquiz_view_exception
+     * @throws \moodle_exception
      */
     public function run_questionbank() {
         global $PAGE;
-        $PAGE->set_url(new moodle_url('/mod/studentquiz/view.php', array('cmid' => $this->cm->id)));
+        $PAGE->set_url(new \moodle_url('/mod/studentquiz/view.php', array('cmid' => $this->cm->id)));
         $PAGE->set_context($this->ctx);
         // Hard coded.
         $pagevars = array(
@@ -113,10 +109,10 @@ class mod_studentquiz_bank_view_test extends advanced_testcase {
             'showallprinted' => 0,
         );
 
-        $report = new mod_studentquiz_report($this->cm->id);
-        $questionbank = new \mod_studentquiz\question\bank\studentquiz_bank_view(
-            new question_edit_contexts(context_module::instance($this->cm->id))
-            , new moodle_url('/mod/studentquiz/view.php', array('cmid' => $this->cm->id))
+        $report = new \mod_studentquiz_report($this->cm->id);
+        $questionbank = new studentquiz_bank_view(
+            new \question_edit_contexts(\context_module::instance($this->cm->id))
+            , new \moodle_url('/mod/studentquiz/view.php', array('cmid' => $this->cm->id))
             , $this->course
             , $this->cm
             , $this->studentquiz
@@ -141,7 +137,7 @@ class mod_studentquiz_bank_view_test extends advanced_testcase {
         $this->cm = get_coursemodule_from_instance('studentquiz', $this->studentquiz->id);
 
         $this->questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
-        $this->ctx = context_module::instance($this->cm->id);
+        $this->ctx = \context_module::instance($this->cm->id);
 
         // Retrieve created category by context.
         $this->cat = question_get_default_category($this->ctx->id);
@@ -170,11 +166,11 @@ class mod_studentquiz_bank_view_test extends advanced_testcase {
 
     /**
      * Create question rate
-     * @param stdClass $question
+     * @param \stdClass $question
      * @param int $userid
      */
     protected function create_rate($question, $userid) {
-        $raterecord = new stdClass();
+        $raterecord = new \stdClass();
         $raterecord->rate = 5;
         $raterecord->questionid = $question->id;
         $raterecord->userid = $userid;
@@ -182,11 +178,11 @@ class mod_studentquiz_bank_view_test extends advanced_testcase {
 
     /**
      * Create question comment
-     * @param stdClass $question
+     * @param \stdClass $question
      * @param int $userid
      */
     protected function create_comment($question, $userid) {
-        $commentrecord = new stdClass();
+        $commentrecord = new \stdClass();
         $commentrecord->questionid = $question->id;
         $commentrecord->userid = $userid;
 
@@ -222,13 +218,13 @@ class mod_studentquiz_bank_view_test extends advanced_testcase {
 
     /**
      * Display question bank
-     * @param mod_studentquiz\question\bank\studentquiz_bank_view $questionbank
+     * @param studentquiz_bank_view $questionbank
      * @param int $qpage
      * @param int $qperpage
      * @param int $recurse
      * @param int $showhidden
      * @param int $qbshowtext
-     * @return string
+     * @return html Output.
      */
     protected function displayqb($questionbank, $qpage = 0, $qperpage = 20, $recurse = 1, $showhidden = 0, $qbshowtext = 0) {
         $cat = $this->cat->id . "," . $this->ctx->id;

--- a/tests/comment_test.php
+++ b/tests/comment_test.php
@@ -14,18 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for comment area.
- *
- * @package    mod_studentquiz
- * @copyright  2020 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die('Direct Access is forbidden!');
+namespace mod_studentquiz;
 
 use mod_studentquiz\commentarea\comment;
-use mod_studentquiz\utils;
 
 /**
  * Unit tests for comment area.
@@ -34,20 +25,20 @@ use mod_studentquiz\utils;
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_comment_testcase extends advanced_testcase {
+class comment_test extends \advanced_testcase {
 
     /**
-     * @var stdClass the StudentQuiz activity created in setUp.
+     * @var \stdClass the StudentQuiz activity created in setUp.
      */
     protected $studentquiz;
 
     /**
-     * @var context_module the corresponding activity context.
+     * @var \context_module the corresponding activity context.
      */
     protected $context;
 
     /**
-     * @var stdClass the corresponding course_module.
+     * @var \stdClass the corresponding course_module.
      */
     protected $cm;
 
@@ -61,19 +52,19 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
      */
     protected $questions;
 
-    /** @var mod_studentquiz\commentarea\container */
+    /** @var commentarea\container */
     protected $commentarea;
 
     /** @var int - Value of Root comment. */
     protected $rootid;
 
-    /** @var stdClass - Course. */
+    /** @var \stdClass - Course. */
     protected $course;
 
-    /** @var mod_studentquiz\commentarea\container - Comment area has disabled period setting. */
+    /** @var commentarea\container - Comment area has disabled period setting. */
     protected $commentareanoperiod;
 
-    /** @var mod_studentquiz\commentarea\container - Comment area has enable period setting. */
+    /** @var commentarea\container - Comment area has enable period setting. */
     protected $commentareahasperiod;
 
     /** @var array - Users list. */
@@ -123,7 +114,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
                 'forcecommenting' => 1,
                 'publishnewquestion' => 1
         ));
-        $this->context = context_module::instance($activity->cmid);
+        $this->context = \context_module::instance($activity->cmid);
         $this->studentquiz = mod_studentquiz_load_studentquiz($activity->cmid, $this->context->id);
         $this->cm = get_coursemodule_from_id('studentquiz', $activity->cmid);
 
@@ -147,9 +138,9 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
 
         $this->questions = [$q1, $q2];
 
-        $this->commentarea = new \mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm,
+        $this->commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm,
             $this->context, $this->users[0]);
-        $this->rootid = \mod_studentquiz\commentarea\container::PARENTID;
+        $this->rootid = commentarea\container::PARENTID;
 
         $this->generate_comment_list_for_sort();
 
@@ -162,7 +153,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
      *
      * @param int $id - Comment ID.
      * @param bool $convert - Is convert to object data.
-     * @return comment|stdClass
+     * @return comment|\stdClass
      */
     private function get_comment_by_id($id, $convert = true) {
         $comment = $this->commentarea->query_comment_by_id($id);
@@ -201,10 +192,10 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
      */
     public function test_initial() {
         $question = $this->questions[0];
-        $this->equalTo($question->id, $this->commentarea->get_question()->id);
-        $this->equalTo($this->cm->id, $this->commentarea->get_cmid());
-        $this->equalTo($this->studentquiz->id, $this->commentarea->get_studentquiz()->id);
-        $this->equalTo($this->context->id, $this->commentarea->get_context()->id);
+        $this->assertEquals($question->id, $this->commentarea->get_question()->id);
+        $this->assertEquals($this->cm->id, $this->commentarea->get_cmid());
+        $this->assertEquals($this->studentquiz->id, $this->commentarea->get_studentquiz()->id);
+        $this->assertEquals($this->context->id, $this->commentarea->get_context()->id);
     }
 
     /**
@@ -304,7 +295,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         // Re-init SQ.
         $this->studentquiz = mod_studentquiz_load_studentquiz($this->cm->id, $this->context->id);
         // Re-init comment area.
-        $this->commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context);
+        $this->commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context);
         $comment = $this->get_comment_by_id($comment->get_id(), false);
         // Now report is turned on. It will return true.
         $this->assertTrue($comment->can_report());
@@ -341,7 +332,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         $q1 = $this->questions[1];
         $base = $this->commentarea;
         // Test sort by date asc.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $base::SORT_DATE_ASC);
         $comments = $commentarea->fetch_all(5);
         $this->assertEquals($this->users[0]->id, $comments[0]->get_comment_data()->userid);
@@ -351,7 +342,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         $this->assertEquals($this->users[4]->id, $comments[4]->get_comment_data()->userid);
 
         // Test sort by desc.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $base::SORT_DATE_DESC);
         $comments = $commentarea->fetch_all(5);
         $this->assertEquals($this->users[5]->id, $comments[0]->get_comment_data()->userid);
@@ -361,7 +352,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         $this->assertEquals($this->users[1]->id, $comments[4]->get_comment_data()->userid);
 
         // Test sort by first name asc.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $base::SORT_FIRSTNAME_ASC);
         $comments = $commentarea->fetch_all(5);
         $this->assertEquals($this->users[0]->id, $comments[0]->get_comment_data()->userid);
@@ -371,7 +362,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         $this->assertEquals($this->users[4]->id, $comments[4]->get_comment_data()->userid);
 
         // Test sort by first name desc.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $base::SORT_FIRSTNAME_DESC);
         $comments = $commentarea->fetch_all(5);
         $this->assertEquals($this->users[5]->id, $comments[0]->get_comment_data()->userid);
@@ -381,7 +372,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         $this->assertEquals($this->users[3]->id, $comments[4]->get_comment_data()->userid);
 
         // Test sort by last name asc.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $base::SORT_LASTNAME_ASC);
         $comments = $commentarea->fetch_all(5);
         $this->assertEquals($this->users[3]->id, $comments[0]->get_comment_data()->userid);
@@ -391,7 +382,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         $this->assertEquals($this->users[5]->id, $comments[4]->get_comment_data()->userid);
 
         // Test sort by last name desc.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $base::SORT_LASTNAME_DESC);
         $comments = $commentarea->fetch_all(5);
         $this->assertEquals($this->users[4]->id, $comments[0]->get_comment_data()->userid);
@@ -409,7 +400,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         $user = $this->users[0];
         $q1 = $this->questions[1];
         $this->setUser($user);
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context);
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context);
         $sortable = $commentarea->get_sortable();
         // Ok we can only sort by date.
         $this->assertEquals([
@@ -418,32 +409,32 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         ], $sortable);
 
         // Try to pass sort firstname asc. Expect FAIL.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $commentarea::SORT_FIRSTNAME_ASC);
         $this->assertNotEquals($commentarea->get_sort_feature(), $commentarea::SORT_FIRSTNAME_ASC);
 
         // Try to pass sort firstname desc. Expect FAIL.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $commentarea::SORT_FIRSTNAME_DESC);
         $this->assertNotEquals($commentarea->get_sort_feature(), $commentarea::SORT_FIRSTNAME_DESC);
 
         // Try to pass sort lastname asc. Expect FAIL.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $commentarea::SORT_LASTNAME_ASC);
         $this->assertNotEquals($commentarea->get_sort_feature(), $commentarea::SORT_LASTNAME_ASC);
 
         // Try to pass sort lastname desc. Expect FAIL.
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $commentarea::SORT_LASTNAME_DESC);
         $this->assertNotEquals($commentarea->get_sort_feature(), $commentarea::SORT_LASTNAME_DESC);
 
         // Try to pass sort date desc. Of course it works!
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $commentarea::SORT_DATE_DESC);
         $this->assertEquals($commentarea->get_sort_feature(), $commentarea::SORT_DATE_DESC);
 
         // Try to pass sort date asc. Of course it works!
-        $commentarea = new mod_studentquiz\commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
+        $commentarea = new commentarea\container($this->studentquiz, $q1, $this->cm, $this->context, null,
                 $commentarea::SORT_DATE_ASC);
         $this->assertEquals($commentarea->get_sort_feature(), $commentarea::SORT_DATE_ASC);
     }
@@ -462,7 +453,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
      * Set up SQ disabled period setting + seed some comments.
      *
      * @param int $period
-     * @return \mod_studentquiz\commentarea\container
+     * @return commentarea\container
      */
     private function seed_studentquiz_period_setting($period) {
         global $DB;
@@ -473,7 +464,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
                 'forcecommenting' => 1,
                 'publishnewquestion' => 1
         ));
-        $context = context_module::instance($activity->cmid);
+        $context = \context_module::instance($activity->cmid);
 
         $studentquiz = mod_studentquiz_load_studentquiz($activity->cmid, $this->context->id);
         $studentquiz->commentdeletionperiod = $period;
@@ -490,7 +481,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
         ]);
         $q1 = \question_bank::load_question($q1->id);
 
-        $commentarea = new \mod_studentquiz\commentarea\container($studentquiz, $q1, $cm, $context, $this->users[0]);
+        $commentarea = new commentarea\container($studentquiz, $q1, $cm, $context, $this->users[0]);
 
         // Seed a comment.
         $DB->insert_record('studentquiz_comment', (object) [
@@ -591,7 +582,7 @@ class mod_studentquiz_comment_testcase extends advanced_testcase {
      * Test extract comment histories to render.
      */
     public function test_extract_comment_histories_to_render() {
-        $mockhistory = new stdClass();
+        $mockhistory = new \stdClass();
         $mockhistory->id = 1;
         $mockhistory->timemodified = 1;
         $mockhistory->userid = $this->users[0]->id;

--- a/tests/cron_test.php
+++ b/tests/cron_test.php
@@ -14,15 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Cron test.
- *
- * @package    mod_studentquiz
- * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die();
+namespace mod_studentquiz;
 
 /**
  * Cron test.
@@ -31,27 +23,27 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright  2020 Huong Nguyen <huongnv13@gmail.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_cron_testcase extends advanced_testcase {
+class cron_test extends \advanced_testcase {
 
-    /** @var stdClass */
+    /** @var \stdClass */
     protected $course;
 
-    /** @var stdClass */
+    /** @var \stdClass */
     protected $student1;
 
-    /** @var stdClass */
+    /** @var \stdClass */
     protected $student2;
 
-    /** @var stdClass */
+    /** @var \stdClass */
     protected $teacher;
 
-    /** @var stdClass */
+    /** @var \stdClass */
     protected $studentquizdata;
 
     /** @var int */
     protected $cmid;
 
-    /** @var stdClass */
+    /** @var \stdClass */
     protected $studentquiz;
 
     /** @var array */
@@ -94,7 +86,7 @@ class mod_studentquiz_cron_testcase extends advanced_testcase {
         ];
 
         $this->cmid = $generator->create_module('studentquiz', $this->studentquizdata)->cmid;
-        $this->studentquiz = mod_studentquiz_load_studentquiz($this->cmid, context_module::instance($this->cmid)->id);
+        $this->studentquiz = mod_studentquiz_load_studentquiz($this->cmid, \context_module::instance($this->cmid)->id);
 
         // Prepare question.
         $this->setUser($this->student1);
@@ -103,8 +95,8 @@ class mod_studentquiz_cron_testcase extends advanced_testcase {
                 ['name' => 'Student 1 Question', 'category' => $this->studentquiz->categoryid]);
         $this->questions[1] = $questiongenerator->create_question('truefalse', null,
                 ['name' => 'Student 2 Question', 'category' => $this->studentquiz->categoryid]);
-        question_bank::load_question($this->questions[0]->id);
-        question_bank::load_question($this->questions[1]->id);
+        \question_bank::load_question($this->questions[0]->id);
+        \question_bank::load_question($this->questions[1]->id);
         $DB->insert_record('studentquiz_question', (object) ['questionid' => $this->questions[0]->id, 'state' => 0]);
         $DB->insert_record('studentquiz_question', (object) ['questionid' => $this->questions[1]->id, 'state' => 1]);
     }
@@ -131,7 +123,7 @@ class mod_studentquiz_cron_testcase extends advanced_testcase {
         // Execute the cron.
         ob_start();
         cron_setup_user();
-        $cron = new \mod_studentquiz\task\send_no_digest_notification_task();
+        $cron = new task\send_no_digest_notification_task();
         $cron->set_custom_data($customdata);
         $cron->set_component('mod_studentquiz');
         $cron->execute();
@@ -159,7 +151,7 @@ class mod_studentquiz_cron_testcase extends advanced_testcase {
         // Execute the cron.
         ob_start();
         cron_setup_user();
-        $cron = new \mod_studentquiz\task\send_no_digest_notification_task();
+        $cron = new task\send_no_digest_notification_task();
         $cron->set_custom_data($customdata);
         $cron->set_component('mod_studentquiz');
         $cron->execute();
@@ -193,7 +185,7 @@ class mod_studentquiz_cron_testcase extends advanced_testcase {
                 'questionname' => $notifydata->questionname,
         ];
 
-        $notificationqueue = new stdClass();
+        $notificationqueue = new \stdClass();
         $notificationqueue->studentquizid = $notifydata->moduleid;
         $notificationqueue->content = serialize($customdata);
         $notificationqueue->recipientid = $this->student2->id;
@@ -203,7 +195,7 @@ class mod_studentquiz_cron_testcase extends advanced_testcase {
         // Execute the cron.
         ob_start();
         cron_setup_user();
-        $cron = new \mod_studentquiz\task\send_digest_notification_task();
+        $cron = new task\send_digest_notification_task();
         $cron->set_component('mod_studentquiz');
         $cron->execute();
         $output = ob_get_contents();

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -21,15 +21,6 @@
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-defined('MOODLE_INTERNAL') || die();
-
-/**
- * mod_studentquiz data generator
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
 class mod_studentquiz_generator extends testing_module_generator {
     /**
      * @var int keep track of how many StudentQuiz have been created.

--- a/tests/generator_test.php
+++ b/tests/generator_test.php
@@ -14,16 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Data generator test
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die();
-
+namespace mod_studentquiz;
 
 /**
  * Data generator test
@@ -32,11 +23,11 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_generator_testcase extends advanced_testcase {
+class generator_test extends \advanced_testcase {
 
     /**
      * Test create comment
-     * @throws coding_exception
+     * @throws \coding_exception
      */
     public function test_create_comment() {
         global $DB;
@@ -51,7 +42,7 @@ class mod_studentquiz_generator_testcase extends advanced_testcase {
         $count = $DB->count_records('studentquiz_comment');
         $user = $this->getDataGenerator()->create_user();
 
-        $commentrecord = new stdClass();
+        $commentrecord = new \stdClass();
         $commentrecord->questionid = $question->id;
         $commentrecord->userid = $user->id;
 
@@ -61,7 +52,7 @@ class mod_studentquiz_generator_testcase extends advanced_testcase {
 
     /**
      * Test create rate
-     * @throws coding_exception
+     * @throws \coding_exception
      */
     public function test_create_rate() {
         global $DB;
@@ -77,7 +68,7 @@ class mod_studentquiz_generator_testcase extends advanced_testcase {
 
         $user = $this->getDataGenerator()->create_user();
 
-        $raterecord = new stdClass();
+        $raterecord = new \stdClass();
         $raterecord->rate = 5;
         $raterecord->questionid = $question->id;
         $raterecord->userid = $user->id;

--- a/tests/permissions_test.php
+++ b/tests/permissions_test.php
@@ -14,15 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests permission namespace.
- *
- * @package    mod_studentquiz
- * @copyright  2020 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die('Direct Access is forbidden!');
+namespace mod_studentquiz;
 
 use mod_studentquiz\access\context_override;
 
@@ -33,12 +25,12 @@ use mod_studentquiz\access\context_override;
  * @copyright  2020 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_permissions_testcase extends advanced_testcase {
+class permissions_test extends \advanced_testcase {
 
     /**
      * Setup test
      *
-     * @throws coding_exception
+     * @throws \coding_exception
      */
     protected function setUp(): void {
         global $DB;
@@ -55,7 +47,7 @@ class mod_studentquiz_permissions_testcase extends advanced_testcase {
     /**
      * Tear down test
      *
-     * @throws coding_exception
+     * @throws \coding_exception
      */
     public function tearDown(): void {
         parent::tearDown();
@@ -67,8 +59,6 @@ class mod_studentquiz_permissions_testcase extends advanced_testcase {
      * after adding a capability and then after removing that capability again.
      */
     public function test_context_override() {
-        global $CFG;
-
         $this->resetAfterTest();
         $user = $this->getDataGenerator()->create_user();
         $course = $this->getDataGenerator()->create_course();
@@ -76,7 +66,7 @@ class mod_studentquiz_permissions_testcase extends advanced_testcase {
         $context = \context_system::instance();
         $studentquiz = $this->getDataGenerator()->create_module('studentquiz',
                 ['course' => $course->id], ['anonymrank' => true]);
-        $contextstudentquiz = context_module::instance($studentquiz->coursemodule);
+        $contextstudentquiz = \context_module::instance($studentquiz->coursemodule);
 
         $this->getDataGenerator()->role_assign($roleid, $user->id, $context->id);
         $this->setUser($user);

--- a/tests/privacy_test.php
+++ b/tests/privacy_test.php
@@ -14,17 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Data provider tests for booking system module.
- *
- * @package    mod_studentquiz
- * @copyright  2018 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
+namespace mod_studentquiz;
 
 use core_privacy\local\request\transform;
 use core_privacy\local\request\userlist;
@@ -33,15 +23,15 @@ use mod_studentquiz\local\studentquiz_helper;
 use mod_studentquiz\privacy\provider;
 use core_privacy\local\request\approved_contextlist;
 use core_privacy\local\request\writer;
-use mod_studentquiz\utils;
 
 /**
  * Data provider testcase class.
  *
  * @package    mod_studentquiz
+ * @copyright  2018 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_privacy_testcase extends provider_testcase {
+class privacy_test extends provider_testcase {
 
     /**
      * @var array
@@ -114,8 +104,8 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
     /**
      * Set up data required for the test case.
      *
-     * @throws dml_exception
-     * @throws moodle_exception
+     * @throws \dml_exception
+     * @throws \moodle_exception
      */
     public function setUp(): void {
         $this->resetAfterTest();
@@ -144,15 +134,15 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
         $cmid3 = $generator->create_module('studentquiz', $studentquizdata)->cmid;
 
         $this->studentquiz = [
-                mod_studentquiz_load_studentquiz($cmid1, context_module::instance($cmid1)->id),
-                mod_studentquiz_load_studentquiz($cmid2, context_module::instance($cmid2)->id),
-                mod_studentquiz_load_studentquiz($cmid3, context_module::instance($cmid3)->id),
+                mod_studentquiz_load_studentquiz($cmid1, \context_module::instance($cmid1)->id),
+                mod_studentquiz_load_studentquiz($cmid2, \context_module::instance($cmid2)->id),
+                mod_studentquiz_load_studentquiz($cmid3, \context_module::instance($cmid3)->id),
         ];
 
         $this->contexts = [
-                context_module::instance($this->studentquiz[0]->coursemodule),
-                context_module::instance($this->studentquiz[1]->coursemodule),
-                context_module::instance($this->studentquiz[2]->coursemodule)
+                \context_module::instance($this->studentquiz[0]->coursemodule),
+                \context_module::instance($this->studentquiz[1]->coursemodule),
+                \context_module::instance($this->studentquiz[2]->coursemodule)
         ];
 
         // Create questions for StudentQuiz.
@@ -249,7 +239,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
     /**
      * Test get context list for user id.
      *
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_get_contexts_for_userid() {
         // Get contexts for the first user.
@@ -271,7 +261,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * Test export data for second user.
      *
      * @throws coding_exception
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_export_first_user_data() {
         $contextids = [$this->contexts[0]->id, $this->contexts[1]->id];
@@ -431,7 +421,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * Test export data for second user.
      *
      * @throws coding_exception
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_export_second_user_data() {
         $contextids = [$this->contexts[0]->id, $this->contexts[1]->id];
@@ -586,7 +576,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * Test delete data for all user in the context.
      *
      * @throws coding_exception
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_delete_data_for_all_users_in_context() {
         global $DB;
@@ -643,7 +633,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
     /**
      * Test delete personal data for one user.
      *
-     * @throws dml_exception
+     * @throws \dml_exception
      * @throws coding_exception
      */
     public function test_delete_data_for_user() {
@@ -662,7 +652,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
 
         // Delete data belong to first user.
         // When running the whole cronjob, privacy task for Question plugin will be called before StudentQuiz.
-        core_question\privacy\provider::delete_data_for_user($appctx);
+        \core_question\privacy\provider::delete_data_for_user($appctx);
         provider::delete_data_for_user($appctx);
 
         // Check question owner of deleting user is change to guest.
@@ -744,7 +734,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * Test get users in context with question's rating condition.
      *
      * @throws coding_exception
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_get_users_in_context_rating() {
         // Another user create question, then first user rate it.
@@ -770,7 +760,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * Test get users in context with question's comment condition.
      *
      * @throws coding_exception
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_get_users_in_context_comment() {
         // Another user create question, then first user comment it.
@@ -796,7 +786,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * Test get users in context with question's comment condition.
      *
      * @throws coding_exception
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_get_users_in_context_comment_history() {
         // Another user create question, then first user comment it.
@@ -816,7 +806,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
     /**
      * Test get users in context with question's attempt condition.
      *
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_get_users_in_context_attempt() {
         // Create attempt for the first user.
@@ -838,7 +828,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
     /**
      * Test get users in context with question's notification condition.
      *
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_get_users_in_context_notification() {
         // Create attempt for the first user.
@@ -878,7 +868,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * Test delete data for users from one context.
      *
      * @throws coding_exception
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     public function test_delete_data_for_users() {
         global $DB;
@@ -968,7 +958,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
         ));
 
         $this->setUser($rootuser);
-        return question_bank::load_question($question->id);
+        return \question_bank::load_question($question->id);
     }
 
     /**
@@ -976,7 +966,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      *
      * @param int $questionid
      * @return object
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     protected function create_question_approval($questionid) {
         global $DB;
@@ -1000,7 +990,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * @param int $questionid
      * @param int $userid
      * @return object
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     protected function create_rate($questionid, $userid) {
         global $DB;
@@ -1028,7 +1018,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * @param int $edit
      * @param int $edituserid
      * @return object
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     protected function create_comment($questionid, $userid, $parentid = 0, $delete = 0, $deleteuserid = 0, $edit = 0,
         $edituserid = 0) {
@@ -1083,7 +1073,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * @param int $userid
      * @param int $studentquizid
      * @return object
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     protected function create_progress($questionid, $userid, $studentquizid) {
         global $DB;
@@ -1111,7 +1101,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * @param int $userid
      * @param int $categoryid
      * @return object
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     protected function create_attempt($studentquizid, $userid, $categoryid) {
         global $DB;
@@ -1135,7 +1125,7 @@ class mod_studentquiz_privacy_testcase extends provider_testcase {
      * @param int $studentquizid
      * @param int $userid
      * @return object
-     * @throws dml_exception
+     * @throws \dml_exception
      */
     protected function create_notification($studentquizid, $userid) {
         global $DB;

--- a/tests/report_test.php
+++ b/tests/report_test.php
@@ -14,13 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for mod/studentquiz/reportstat.php.
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_studentquiz;
 
 defined('MOODLE_INTERNAL') || die('Direct Access is forbidden!');
 
@@ -36,25 +30,25 @@ require_once($CFG->dirroot . '/mod/studentquiz/reportlib.php');
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_report_testcase extends advanced_testcase {
+class report_test extends \advanced_testcase {
 
     /**
-     * @var stdClass the StudentQuiz activity created in setUp.
+     * @var \stdClass the StudentQuiz activity created in setUp.
      */
     protected $studentquiz;
 
     /**
-     * @var context_module the corresponding activity context.
+     * @var \context_module the corresponding activity context.
      */
     protected $context;
 
     /**
-     * @var stdClass the corresponding course_module.
+     * @var \stdClass the corresponding course_module.
      */
     protected $cm;
 
     /**
-     * @var mod_studentquiz_report the report created in setUp.
+     * @var \mod_studentquiz_report the report created in setUp.
      */
     protected $report;
 
@@ -70,7 +64,7 @@ class mod_studentquiz_report_testcase extends advanced_testcase {
 
     /**
      * Setup test
-     * @throws coding_exception
+     * @throws \coding_exception
      */
     protected function setUp(): void {
         global $DB;
@@ -89,10 +83,10 @@ class mod_studentquiz_report_testcase extends advanced_testcase {
             'incorrectanswerquantifier' => -1,
             'excluderoles' => [3 => 3, 5 => 5],
         ));
-        $this->context = context_module::instance($activity->cmid);
+        $this->context = \context_module::instance($activity->cmid);
         $this->studentquiz = mod_studentquiz_load_studentquiz($activity->cmid, $this->context->id);
         $this->cm = get_coursemodule_from_id('studentquiz', $activity->cmid);
-        $this->report = new mod_studentquiz_report($activity->cmid);
+        $this->report = new \mod_studentquiz_report($activity->cmid);
 
         // Create users.
         $usernames = array('Peter', 'Lisa', 'Sandra', 'Tobias', 'Gabi', 'Sepp');
@@ -123,7 +117,7 @@ class mod_studentquiz_report_testcase extends advanced_testcase {
         $attempt = mod_studentquiz_generate_attempt($questionids, $this->studentquiz, $users[0]->id);
         $questionids = explode(',', $attempt->ids);
 
-        $questionusage = question_engine::load_questions_usage_by_activity($attempt->questionusageid);
+        $questionusage = \question_engine::load_questions_usage_by_activity($attempt->questionusageid);
         $post = $questionusage->prepare_simulated_post_data([1 => ['answer' => 1, '-submit' => 1]]);
         $questionusage->process_all_actions(null, $post);
 
@@ -133,7 +127,7 @@ class mod_studentquiz_report_testcase extends advanced_testcase {
 
         mod_studentquiz_add_question_to_attempt($questionusage, $this->studentquiz, $questionids, 2);
 
-        question_engine::save_questions_usage_by_activity($questionusage);
+        \question_engine::save_questions_usage_by_activity($questionusage);
         $this->setAdminUser();
     }
 
@@ -172,7 +166,7 @@ class mod_studentquiz_report_testcase extends advanced_testcase {
         set_config('excluderoles', '1,2,3,4', 'studentquiz');
         set_config('allowedrolestoshow', '3,4,5,6', 'studentquiz');
 
-        $rolescanbeexcluded = mod_studentquiz_report::get_roles_which_can_be_exculded();
+        $rolescanbeexcluded = \mod_studentquiz_report::get_roles_which_can_be_exculded();
         $this->assertCount(4, $rolescanbeexcluded);
         // The role to show are 3, 4, 5 and 6 since it is defined in rolestoshow.
         $this->assertEqualsCanonicalizing(['3', '4', '5', '6'], array_keys($rolescanbeexcluded));
@@ -184,7 +178,7 @@ class mod_studentquiz_report_testcase extends advanced_testcase {
 
         // Test if only excluderoles is empty.
         set_config('excluderoles', '', 'studentquiz');
-        $rolescanbeexcluded = mod_studentquiz_report::get_roles_which_can_be_exculded();
+        $rolescanbeexcluded = \mod_studentquiz_report::get_roles_which_can_be_exculded();
         $this->assertCount(4, $rolescanbeexcluded);
         $this->assertEqualsCanonicalizing(['3', '4', '5', '6'], array_keys($rolescanbeexcluded));
         // All roles are not selected by default.
@@ -197,14 +191,14 @@ class mod_studentquiz_report_testcase extends advanced_testcase {
         set_config('excluderoles', '1,2,3,4', 'studentquiz');
         set_config('allowedrolestoshow', '', 'studentquiz');
         // None of the roles are returned.
-        $rolescanbeexcluded = mod_studentquiz_report::get_roles_which_can_be_exculded();
+        $rolescanbeexcluded = \mod_studentquiz_report::get_roles_which_can_be_exculded();
         $this->assertCount(0, $rolescanbeexcluded);
 
         // Test if both config is empty.
         set_config('excluderoles', '', 'studentquiz');
         set_config('allowedrolestoshow', '', 'studentquiz');
         // None of the roles are returned.
-        $rolescanbeexcluded = mod_studentquiz_report::get_roles_which_can_be_exculded();
+        $rolescanbeexcluded = \mod_studentquiz_report::get_roles_which_can_be_exculded();
         $this->assertCount(0, $rolescanbeexcluded);
     }
 

--- a/tests/viewlib_test.php
+++ b/tests/viewlib_test.php
@@ -14,13 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for (some of) mod/studentquiz/viewlib.php.
- *
- * @package    mod_studentquiz
- * @copyright  2017 HSR (http://www.hsr.ch)
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_studentquiz;
 
 defined('MOODLE_INTERNAL') || die('Direct Access is forbidden!');
 
@@ -35,18 +29,18 @@ require_once($CFG->dirroot . '/mod/studentquiz/reportlib.php');
  * @copyright  2017 HSR (http://www.hsr.ch)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mod_studentquiz_viewlib_testcase extends advanced_testcase {
+class viewlib_test extends \advanced_testcase {
     /**
      * @var studentquiz_view
      */
     private $viewlib;
 
-    /** @var stdClass */
+    /** @var \stdClass */
     private $cm;
 
     /**
      * Setup test
-     * @throws coding_exception
+     * @throws \coding_exception
      */
     protected function setUp(): void {
         global $DB;
@@ -61,14 +55,14 @@ class mod_studentquiz_viewlib_testcase extends advanced_testcase {
             , array('course' => $course->id),  array('anonymrank' => true));
 
         $this->cm = get_coursemodule_from_id('studentquiz', $studentquiz->cmid);
-        $context = context_module::instance($this->cm->id);
+        $context = \context_module::instance($this->cm->id);
 
         // Some internal moodle functions (e.g. question_edit_setup()) require the cmid to be found in $_xxx['cmid'].
         $_GET['cmid'] = $this->cm->id;
 
         // Satisfy codechecker: $course $cm $studentquiz $userid.
-        $report = new mod_studentquiz_report($this->cm->id);
-        $this->viewlib = new mod_studentquiz_view($course, $context, $this->cm,
+        $report = new \mod_studentquiz_report($this->cm->id);
+        $this->viewlib = new \mod_studentquiz_view($course, $context, $this->cm,
             $studentquiz, $user->id, $report);
     }
 
@@ -85,7 +79,7 @@ class mod_studentquiz_viewlib_testcase extends advanced_testcase {
 
     public function test_get_viewurl() {
         $viewurl = $this->viewlib->get_viewurl();
-        $expectedurl = new moodle_url('/mod/studentquiz/view.php', array('cmid' => $this->cm->id));
+        $expectedurl = new \moodle_url('/mod/studentquiz/view.php', array('cmid' => $this->cm->id));
         $this->assertEquals('/moodle/mod/studentquiz/view.php', $viewurl->get_path());
         $this->assertTrue($expectedurl->compare($viewurl, URL_MATCH_EXACT));
     }


### PR DESCRIPTION
The automated tests are now failing because of a new CodeChecker rule. For example:

FILE: /home/runner/work/moodle-mod_studentquiz/moodle-mod_studentquiz/moodle/mod/studentquiz/tests/report_test.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------
39 | WARNING | PHPUnit testcase name "mod_studentquiz_report_testcase" does not match file name "report_test"
| | (moodle.PHPUnit.TestCaseNames.NoMatch)
39 | WARNING | PHUnit class "mod_studentquiz_report_testcase" does not have any namespace. It is recommended to add it to the
| | "mod_studentquiz" namespace, using more levels if needed, in order to match the code being tested
| | (moodle.PHPUnit.TestCaseNames.MissingNS)
------------------------------------------------------------------------------------------------------------------------------------

FILE: ...nner/work/moodle-mod_studentquiz/moodle-mod_studentquiz/moodle/mod/studentquiz/backup/moodle2/restore_studentquiz_stepslib.php
11------------------------------------------------------------------------------------------------------------------------------------
12FOUND 1 ERROR AFFECTING 1 LINE
13------------------------------------------------------------------------------------------------------------------------------------
14 29 | ERROR | Unexpected MOODLE_INTERNAL check. No side effects or multiple artifacts detected.
15 | | (moodle.Files.MoodleInternal.MoodleInternalNotNeeded)
16------------------------------------------------------------------------------------------------------------------------------------

I've fixed these errors in this pull request.
