### PR TITLE
Fix bug missing some override permissions of context module

### DIFF
--- a/tests/permissions_test.php
+++ b/tests/permissions_test.php
@@ -63,26 +63,45 @@ class permissions_test extends \advanced_testcase {
         $user = $this->getDataGenerator()->create_user();
         $course = $this->getDataGenerator()->create_course();
         $roleid = $this->getDataGenerator()->create_role();
-        $context = \context_system::instance();
+        $contextsystem = \context_system::instance();
         $studentquiz = $this->getDataGenerator()->create_module('studentquiz',
                 ['course' => $course->id], ['anonymrank' => true]);
         $contextstudentquiz = \context_module::instance($studentquiz->coursemodule);
 
-        $this->getDataGenerator()->role_assign($roleid, $user->id, $context->id);
+        $this->getDataGenerator()->role_assign($roleid, $user->id, $contextsystem->id);
         $this->setUser($user);
 
         // First the user doesn't have the context specific capability.
         $this->assertFalse(has_capability('moodle/question:editall', $contextstudentquiz));
 
-        // Then we assign a capability and run the the ensure function so the context specific capability is added.
-        assign_capability('mod/studentquiz:manage', CAP_ALLOW, $roleid, $context, true);
+        // Then we assign a capability in context system.
+        assign_capability('mod/studentquiz:manage', CAP_ALLOW, $roleid, $contextsystem, true);
+
+        // Un-assign the needed capabilities.
+        assign_capability('moodle/question:editall', CAP_PREVENT, $roleid, $contextsystem, true);
+
+        // We assign another capabilities which is not in the context_override list to check that it will not be affected.
+        assign_capability('mod/studentquiz:canselfratecomment', CAP_ALLOW, $roleid, $contextstudentquiz, true);
         context_override::ensure_permissions_are_right($contextstudentquiz);
 
+        $this->assertTrue(has_capability('mod/studentquiz:manage', $contextstudentquiz));
         $this->assertTrue(has_capability('moodle/question:editall', $contextstudentquiz));
+        $this->assertTrue(has_capability('mod/studentquiz:canselfratecomment', $contextstudentquiz));
 
-        // Then we remove that capability again and the user has not anymore the context specific capability.
-        unassign_capability('mod/studentquiz:manage', $roleid, $context);
+        // Then we remove that capability in context system and the user has not anymore the context specific capability.
+        unassign_capability('mod/studentquiz:manage', $roleid, $contextsystem);
         context_override::ensure_permissions_are_right($contextstudentquiz);
+
+        $this->assertFalse(has_capability('mod/studentquiz:manage', $contextstudentquiz));
         $this->assertFalse(has_capability('moodle/question:editall', $contextstudentquiz));
+        $this->assertTrue(has_capability('mod/studentquiz:canselfratecomment', $contextstudentquiz));
+
+        // Assign the capability in context module.
+        assign_capability('mod/studentquiz:manage', CAP_ALLOW, $roleid, $contextstudentquiz, true);
+        context_override::ensure_permissions_are_right($contextstudentquiz);
+
+        $this->assertTrue(has_capability('mod/studentquiz:manage', $contextstudentquiz));
+        $this->assertTrue(has_capability('moodle/question:editall', $contextstudentquiz));
+        $this->assertTrue(has_capability('mod/studentquiz:canselfratecomment', $contextstudentquiz));
     }
 }


### PR DESCRIPTION
Some of permissions we set in module (activity) level are removed by the ensure_relation script.
I think that the "no meaning" in the comment is not correct. 

            _// After going through, all remaining caps are excessive have to be usassigned. If there are capabilities in
            // the list not related to required or override, they have **no meaning** anyway, since this list only contains
            // unresolved capabilities._
            
Some of new SQ capabilities allow to override in activity level, but they do not in the list of $studentquizrelation, such as mod/studentquiz:canselfratecomment, mod/studentquiz:pinquestion, mod/studentquiz:canselfcommentprivately, etc.

Steps to reproduce:
1. Remove a role (such as tutor in my video) from the roles with permission list of capability mod/studentquiz:canselfratecomment in context course
2. Add the role about to roles with permission list of capability mod/studentquiz:canselfratecomment in context activity
3. Login in other browser with a user with the role above and access to the SQ above.
4. Reload the allowed list of capability mod/studentquiz:canselfratecomment in the step 2.
Expected result: The selected role (tutor) should be shown in the Roles with permission list of capability mod/studentquiz:canselfratecomment
Actual: The selected role disappear after we reload page.

https://user-images.githubusercontent.com/1708403/153570273-2938dc66-b05f-4a2a-a738-45a4824e95a7.mov

I suggest to remove the code which remove our override capabilities or we add the new capabilities to the $studentquizrelation.

Could you please review it and give me some advice?