### PR TITLE
Fix bug adding filter to 'comment' throws error

### DIFF
--- a/classes/condition/studentquiz_condition.php
+++ b/classes/condition/studentquiz_condition.php
@@ -205,8 +205,8 @@ class studentquiz_condition extends \core_question\bank\search\condition {
                 return 'dl.';
             case 'rate':
                 return 'vo.';
-            case 'comment':
-                return 'co.';
+            case 'publiccomment':
+                return 'copub.';
             case 'state':
                 return 'sqs.';
             case 'firstname':

--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -776,8 +776,8 @@ class studentquiz_bank_view extends \core_question\bank\view {
         $this->fields[] = new \user_filter_percent('difficultylevel', get_string('filter_label_difficulty_level', 'studentquiz'),
             true, 'difficultylevel');
 
-        $this->fields[] = new \user_filter_number('comment', get_string('filter_label_comment', 'studentquiz'),
-            true, 'comment');
+        $this->fields[] = new \user_filter_number('publiccomment', get_string('filter_label_comment', 'studentquiz'),
+            true, 'publiccomment');
         $this->fields[] = new \studentquiz_user_filter_text('name', get_string('filter_label_question', 'studentquiz'),
             true, 'name');
         $this->fields[] = new \studentquiz_user_filter_text('questiontext', get_string('filter_label_questiontext', 'studentquiz'),


### PR DESCRIPTION
Step to reproduce the bug:
1. Go to the SQ with atleast 1 question.
2. Open the filter, click on "show more ..."
3. Enter a number in the 'comment' and click filter
![image](https://user-images.githubusercontent.com/1708403/153986552-b0e053f0-54e3-497b-a7a0-8a1378c0c29e.png)

Actual result:
A database error screen will appear:
_Debug info: ERROR: missing FROM-clause entry for table "co"
LINE 45: ...R (dl.difficultylevel IS NULL AND 0 > $6))) AND ((co.comment..._

When we developed the private commenting function, we have modified the comment column and changed the table alias. I updated the table name of the filter in this commit to match with the change in comment column (as default the filter will be base on the public comment)

Hi @timhunt, could you please help me to review this pull request?