### PR TITLE
Fix 'privatecommenting' of non-object errors

### DIFF
--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -137,12 +137,12 @@ class studentquiz_bank_view extends \core_question\bank\view {
      */
     public function __construct($contexts, $pageurl, $course, $cm, $studentquiz, $pagevars, $report) {
         $this->set_filter_post_data();
-        parent::__construct($contexts, $pageurl, $course, $cm);
         global $USER, $PAGE;
         $this->pagevars = $pagevars;
         $this->studentquiz = $studentquiz;
         $this->userid = $USER->id;
         $this->report = $report;
+        parent::__construct($contexts, $pageurl, $course, $cm);
         $this->set_filter_form_fields($this->is_anonymized());
         $this->initialize_filter_form($pageurl);
         $currentgroup = groups_get_activity_group($cm, true);


### PR DESCRIPTION
I have fixed a coding notice in this commit
Step to reproduce:
Step 1: Login as an admin, turn on the _Display debug message_ option in the /admin/settings.php?section=debugging
Step 2: Turn editing 'ON' , add student quiz activity
Step 3: Add questions to Student quiz activity (You can add question either as student/admin/tutor)
Step 4: click on 'Start quiz' to attempt the quiz
After the completion of attempt , click on the following links (T-type , S -sort ,Question, Action , Tag ,My attempt, Difficulty ,Rating ,Comments)

![image](https://user-images.githubusercontent.com/1708403/156314061-dbcebd28-1031-4972-93c8-2ed424961970.png)

Actual Result : Getting the following error on the top of the page 

Notice: Trying to get property 'privatecommenting' of non-object in /var/www/html/moodle/mod/studentquiz/classes/question/bank/studentquiz_bank_view.php on line 947

In some cases, the construct function of \core_question\bank\view call to parse_subsort function. We should assign $this->studentquiz = $studentquiz; first before call the parent::__construct and the overridden parse_subsort function will do the redirection if needed. It also will be better than redirect when we call build_query.

Hi @timhunt , could you please help me to review it?

Thanks.