### PR TITLE
Display error page when Tutor does have 'change state' capability

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -430,7 +430,7 @@ class mod_studentquiz_renderer extends plugin_renderer_base {
         $title = get_string('state_change_tooltip_'.$statename, 'studentquiz');
         $content = $this->output->pix_icon('state_'.$statename, '', 'studentquiz');
 
-        if (question_has_capability_on($question, 'editall')) {
+        if (has_capability('mod/studentquiz:changestate', $this->page->context)) {
             $url = new moodle_url($baseurl, [
                     'approveselected' => $question->id,
                     'q' . $question->id => 1,
@@ -1233,16 +1233,18 @@ EOT;
         }
 
         if ($caneditall) {
-            $output .= html_writer::empty_tag('input', [
-                'class' => 'btn btn-secondary',
-                'type' => 'submit',
-                'name' => 'approveselected',
-                'value' => get_string('state_toggle', 'studentquiz'),
-                'data-action' => 'toggle',
-                'data-togglegroup' => 'qbank',
-                'data-toggle' => 'action',
-                'disabled' => true
-            ]);
+            if (has_capability('mod/studentquiz:changestate', $this->page->context)) {
+                $output .= html_writer::empty_tag('input', [
+                    'class' => 'btn btn-secondary',
+                    'type' => 'submit',
+                    'name' => 'approveselected',
+                    'value' => get_string('state_toggle', 'studentquiz'),
+                    'data-action' => 'toggle',
+                    'data-togglegroup' => 'qbank',
+                    'data-toggle' => 'action',
+                    'disabled' => true
+                ]);
+            }
             $output .= html_writer::empty_tag('input', [
                 'class' => 'btn btn-secondary',
                 'type' => 'submit',

--- a/tests/behat/state_visibility.feature
+++ b/tests/behat/state_visibility.feature
@@ -270,6 +270,7 @@ Feature: Question states and visibility
     Given the following "permission overrides" exist:
       | capability                  | permission | role    | contextlevel | reference |
       | mod/studentquiz:changestate | Allow      | teacher | Course       | C1        |
+      | mod/studentquiz:manage      | Allow      | teacher | Course       | C1        |
     When I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "teacher1"
     And I click on "Create new question" "button"
     And I set the field "item_qtype_truefalse" to "1"
@@ -278,6 +279,7 @@ Feature: Question states and visibility
     And I set the field "Question text" to "The correct answer is false"
     And I press "id_submitbutton"
 
+    And "Change state" "button" should exist
     And I choose "Preview" action for "TF 01" in the question bank
     And I switch to "questionpreview" window
     And the "menustatetype" select box should contain "Disapproved"
@@ -291,6 +293,8 @@ Feature: Question states and visibility
     Then the following "permission overrides" exist:
       | capability                  | permission | role    | contextlevel | reference |
       | mod/studentquiz:changestate | Prevent    | teacher | Course       | C1        |
+    And I reload the page
+    And "Change state" "button" should not exist
     And I choose "Preview" action for "TF 01" in the question bank
     And I switch to "questionpreview" window
     And the "menustatetype" select box should contain "Changed"

--- a/view.php
+++ b/view.php
@@ -87,6 +87,10 @@ if ((optional_param('approveselected', false, PARAM_BOOL) || optional_param('del
         redirect($baseurl, get_string('noquestionsselectedtodoaction', 'studentquiz'),
             null, \core\output\notification::NOTIFY_WARNING);
     }
+    if (!has_capability('mod/studentquiz:changestate', $PAGE->context) && optional_param('approveselected', false, PARAM_BOOL)) {
+        redirect(new moodle_url('view.php', array('id' => $cmid)), get_string('nopermissions', 'error',
+            get_string('studentquiz:changestate', 'studentquiz')), null, \core\output\notification::NOTIFY_WARNING);
+    }
 }
 
 // Since this page has 2 forms interacting with each other, all params must be passed in GET, thus


### PR DESCRIPTION
Hi @timhunt,

In this commit, I have fixed some UI to improve UX.
When the tutor does not have 'changestate' permission set. The page throw error as the image below:
![image](https://user-images.githubusercontent.com/32395146/156725706-6978183f-e2b2-4964-8520-f3ecbd36e953.png)

I have listed cases I have changed when the tutor does not have 'changestate' permission
1. 'Change state' button will be hidden  in the studentquiz view
![image](https://user-images.githubusercontent.com/32395146/156725986-6b373bc3-1ed8-4b30-b7b5-1bd6e4fd0184.png)

2. The icon in state column will be disabled
![image](https://user-images.githubusercontent.com/32395146/156726158-852d964d-94d7-405f-a017-f37f3f19f8be.png)

3. To ensure security, when we copy the URL change state of questions from browser A to another browser, 
I have displayed a warning message.
<img width="775" alt="image" src="https://user-images.githubusercontent.com/32395146/156726625-757c7fb5-7edd-465e-8999-d94d299018f9.png">

I have also updated behat test for this case.
Could you please help me to review it?
Many thanks.
 