### PR TITLE
Fix bug when filter by 'Difficult for me' option

### DIFF
--- a/classes/condition/studentquiz_condition.php
+++ b/classes/condition/studentquiz_condition.php
@@ -168,7 +168,10 @@ class studentquiz_condition extends \core_question\bank\search\condition {
      */
     private function get_special_sql($sqldata, $name) {
         if (substr($sqldata, 0, 12) === 'mydifficulty') {
-            return str_replace('mydifficulty', 'ROUND(1 - (sp.correctattempts / sp.attempts),2)', $sqldata);
+            return str_replace('mydifficulty', '(CASE WHEN sp.attempts > 0 THEN
+                    ROUND(1 - (CAST(sp.correctattempts AS DECIMAL) / CAST(sp.attempts  AS DECIMAL)), 2)
+                    ELSE 0
+                END)', $sqldata);
         }
         if ($name == "onlynew") {
             return str_replace('myattempts', 'sp.attempts', $sqldata);
@@ -184,7 +187,10 @@ class studentquiz_condition extends \core_question\bank\search\condition {
      */
     private function get_sql_field($name) {
         if (substr($name, 0, 12) === 'mydifficulty') {
-            return str_replace('mydifficulty', 'ROUND(1 - (sp.correctattempts / sp.attempts),2)', $name);
+            return str_replace('mydifficulty', '(CASE WHEN sp.attempts > 0 THEN
+                    ROUND(1 - (CAST(sp.correctattempts AS DECIMAL) / CAST(sp.attempts  AS DECIMAL)), 2)
+                    ELSE 0
+                END)', $name);
         }
         if (substr($name, 0, 10) === 'myattempts') {
             return 'sp.attempts';

--- a/tests/behat/startpageview.feature
+++ b/tests/behat/startpageview.feature
@@ -11,21 +11,104 @@ Feature: View comprehensive information about this studentquiz activity
     And the following "users" exist:
       | username | firstname | lastname | email                |
       | teacher1 | Terry1    | Teacher1 | teacher1@example.com |
-      | student1 | Sam1      | Student1 | student1@example.com |
+      | student1 | Student   | One      | student1@example.com |
+      | student2 | Student   | Two      | student2@example.com |
     And the following "course enrolments" exist:
       | user     | course | role           |
       | teacher1 | C1     | editingteacher |
       | student1 | C1     | student        |
+      | student2 | C1     | student        |
     And the following "activities" exist:
       | activity    | name          | intro              | course | idnumber     | publishnewquestion |
       | studentquiz | StudentQuiz 1 | Quiz 1 description | C1     | studentquiz1 | 1                  |
-    And the following "questions" exist:
-      | questioncategory          | qtype | name                       | questiontext                  |
-      | Default for StudentQuiz 1 | essay | Test question to be copied | Write about whatever you want |
 
   @javascript
   Scenario: Check if the default filter settings are visible
     When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
-    And I wait until the page is ready
+
+    # Student 1 create his question.
+    And I click on "Create new question" "button"
+    And I set the field "item_qtype_truefalse" to "1"
+    And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
+    And I set the field "Question name" to "Question 1"
+    And I set the field "Question text" to "The correct answer is false"
+    And I press "id_submitbutton"
+    And I log out
+
+    # Student 2 create his question.
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student2"
+    And I click on "Create new question" "button"
+    And I set the field "item_qtype_truefalse" to "1"
+    And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
+    And I set the field "Question name" to "Question 2"
+    And I set the field "Question text" to "The correct answer is false"
+    And I press "id_submitbutton"
+    And I log out
+
+    # Teacher approve a question.
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "teacher1"
+    And I choose "Preview" action for "Question 1" in the question bank
+    And I switch to "questionpreview" window
+    And I set the field "statetype" to "Approved"
+    And I click on "Change state" "button"
+    And I switch to the main window
+    And I log out
+
+    # Student 1 answer a question.
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
+    And I press "Check"
+    And I click on ".rateable[data-rate='5']" "css_element"
+    And I click on "Abort" "button"
+
+    # Check the Fast filter.
     Then "Filter" "fieldset" should be visible
     And I should see "Fast filter for questions"
+    And I click on "Unanswered" "link"
+    And I press "id_submitbutton"
+    And I should see "Question 1"
+    And I should not see "Question 2"
+    And I click on "Reset" "button"
+
+    And I click on "New" "link"
+    And I press "id_submitbutton"
+    And I should see "Question 2"
+    And I should not see "Question 1"
+    And I click on "Reset" "button"
+
+    And I click on "Approved" "link"
+    And I press "id_submitbutton"
+    And I should see "Question 1"
+    And I should not see "Question 2"
+    And I click on "Reset" "button"
+
+    And I click on "Disapproved" "link"
+    And I click on "Changed" "link"
+    And I click on "Reviewable" "link"
+    And I press "id_submitbutton"
+    And I should see "None of the questions matched your filter criteria. Reset the filter to see all."
+    And I click on "Reset" "button"
+
+    And I click on "Good" "link"
+    And I press "id_submitbutton"
+    And I should see "Question 2"
+    And I should not see "Question 1"
+    And I click on "Reset" "button"
+
+    And I click on "Mine" "link"
+    And I press "id_submitbutton"
+    And I should see "Question 1"
+    And I should not see "Question 2"
+    And I click on "Reset" "button"
+
+    And I click on "Difficult for me" "link"
+    And I press "id_submitbutton"
+    And I should see "Question 2"
+    And I should not see "Question 1"
+    And I click on "Reset" "button"
+
+    And I click on "Difficult for all" "link"
+    And I press "id_submitbutton"
+    And I should see "Question 2"
+    And I should not see "Question 1"


### PR DESCRIPTION
I have fixed the bug throwing error when filter by 'Difficult for me' option

Step to reproduce:
Step 1: Login as an admin, Navigate to any course 
Step 2: Turn editing 'ON' , add student quiz activity
Step 3: Add questions to Student quiz activity
Step 4: click on 'Start quiz' to attempt the quiz
Step 5: After the completion of attempt , click on the "Difficult for me" button  and click on Filter -> got "Error reading from DB" error.
![bddd9c34-d16f-409e-911b-430750aa6fb2](https://user-images.githubusercontent.com/1708403/156751333-1f0c317c-e1d8-4fb7-81fa-85a41db609dc.png)

Debug info: ERROR: division by zero

The filter (fast filter and advance filter) do not have automation test to reduce the obvious bugs like this bug. I've added a Behat test for the fast filter first in this commit. Some other bugs with the filter options in 'show more...' are fixing by our developers, and I will ask them to update a Behat test for them.

Hi @timhunt , could you please help me to review it?

Thanks.
