### PR TITLE
Fix filter errors and add behat in the advance filter

### DIFF
--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -826,7 +826,15 @@ class studentquiz_bank_view extends \core_question\bank\view {
      * but the moodle filter form can only process POST, so we need to copy them there.
      */
     private function modify_base_url() {
-        $this->baseurl->params($_GET);
+        $paramsget = $_GET;
+
+        // Url parameters values can not be arrays, so we get the processed data of form to get the timestamp instead of array.
+        if ($data = $this->filterform->get_data()) {
+            $paramsget['timecreated_sdt'] = $data->timecreated_sdt;
+            $paramsget['timecreated_edt'] = $data->timecreated_edt;
+        }
+
+        $this->baseurl->params($paramsget);
     }
 
     /**
@@ -843,12 +851,12 @@ class studentquiz_bank_view extends \core_question\bank\view {
             redirect($pageurl);
         }
 
-        $this->modify_base_url();
         $this->filterform = new \mod_studentquiz_question_bank_filter_form(
             $this->fields,
             $pageurl->out(),
             array('cmid' => $this->cm->id)
         );
+        $this->modify_base_url();
     }
 
     /**

--- a/styles.css
+++ b/styles.css
@@ -822,3 +822,15 @@
 .path-mod-studentquiz #categoryquestions .header.state {
     text-align: center;
 }
+/* CSS style for message validation form, because the align-items-center is set important in the parent of form-group. */
+@media only screen and (min-width: 396px) {
+    .path-mod-studentquiz #form-advanced-div .form-control-feedback.invalid-feedback {
+        position: absolute;
+    }
+}
+
+@media only screen and (min-width: 576px) {
+    .path-mod-studentquiz #form-advanced-div .form-control-feedback.invalid-feedback {
+        margin-top: 4.5em;
+    }
+}

--- a/tests/behat/filter.feature
+++ b/tests/behat/filter.feature
@@ -1,0 +1,63 @@
+@mod @mod_studentquiz
+Feature: Filtering in Studentquiz view.
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | student1 | Sam1      | Student1 | student1@example.com |
+      | student2 | Sam2      | Student2 | student2@example.com |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | C1     | student |
+      | student2 | C1     | student |
+    And the following "activities" exist:
+      | activity    | name               | intro                     | course | idnumber     | publishnewquestion |
+      | studentquiz | StudentQuiz Test 1 | StudentQuiz description 1 | C1     | studentquiz1 | 1                  |
+    And the following "questions" exist:
+      | questioncategory               | qtype     | name            | questiontext          |
+      | Default for StudentQuiz Test 1 | truefalse | Test question 1 | Answer the question 1 |
+      | Default for StudentQuiz Test 1 | truefalse | Test question 2 | Answer the question 2 |
+
+  @javascript @_switch_window
+  Scenario: Check validation client in the advance filter.
+    When I am on the "StudentQuiz Test 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Show more..." "link"
+    Then I set the field "Rating value" to "TF 01"
+    And I should see "You must enter a number here."
+    And I set the field "Rating value" to ""
+    And I should not see "You must enter a number here."
+
+    And I set the field "Difficulty value" to "TF 01"
+    And I should see "You must enter a number here."
+    And I set the field "Difficulty value" to ""
+    And I should not see "You must enter a number here."
+
+    And I set the field "Comments value" to "TF 01"
+    And I should see "You must enter a number here."
+    And I set the field "Comments value" to ""
+    And I should not see "You must enter a number here."
+
+    And I set the field "My attempts value" to "TF 01"
+    And I should see "You must enter a number here."
+    And I set the field "My attempts value" to ""
+    And I should not see "You must enter a number here."
+
+    And I set the field "My difficulty value" to "TF 01"
+    And I should see "You must enter a number here."
+    And I set the field "My difficulty value" to ""
+    And I should not see "You must enter a number here."
+
+    And I set the field "My Rating value" to "TF 01"
+    And I should see "You must enter a number here."
+    And I set the field "My Rating value" to ""
+    And I should not see "You must enter a number here."
+
+    And I set the following fields to these values:
+      | timecreated_sdt[enabled] | 1 |
+    Then I press "id_submitbutton"
+    And I should see "Test question 1"
+    And I should see "Test question 2"


### PR DESCRIPTION
Hi Tim, 

In this commit, I have fixed errors in the filter of the Studentquiz as the image below:
![telegram-cloud-photo-size-5-6160990514799817129-x](https://user-images.githubusercontent.com/32395146/158363636-d8d1465f-88b0-4a18-8511-15b1d151c75e.jpg)

I. I have update the new form validation in client side:
<img width="820" alt="image" src="https://user-images.githubusercontent.com/32395146/158364281-90414ca7-603a-4b47-b980-0c2423a8fb7d.png">

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/32395146/158364396-b70098bd-5d45-4080-9b81-57c01cb30b19.png">

II. I have also fixed some bugs relating to the filter:
 1. Enable Creation date is after/is before throws error
    - At creation we check enable date is after/is before then click on 'Filter' button. The filter can be run without errors message
 2. Fix validation message display in the responsive UI. 
<img width="538" alt="image" src="https://user-images.githubusercontent.com/32395146/158383966-74ff6f91-64b0-4d27-afc1-ea7673bcbb07.png">

III. The git action errors are not correct:
1. The function names use to override methods from the base class, so I can not update their names.
2. Do not require phpdoc for methods that override base class.

Could you please help me review it?
Many thanks, Tim
