### PR TITLE
Studentquiz: Update css for displaying error form-group

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -822,15 +822,15 @@
 .path-mod-studentquiz #categoryquestions .header.state {
     text-align: center;
 }
-/* CSS style for message validation form, because the align-items-center is set important in the parent of form-group. */
-@media only screen and (min-width: 396px) {
-    .path-mod-studentquiz #form-advanced-div .form-control-feedback.invalid-feedback {
-        position: absolute;
-    }
-}
 
-@media only screen and (min-width: 576px) {
-    .path-mod-studentquiz #form-advanced-div .form-control-feedback.invalid-feedback {
-        margin-top: 4.5em;
-    }
+/* Specific CSS override align-items-center, we need to prevent align-items: center in the form-group. */
+.path-mod-studentquiz #fgroup_id_rate_grp div.align-items-center,
+.path-mod-studentquiz #fgroup_id_rate_grp div.align-items-center,
+.path-mod-studentquiz #fgroup_id_difficultylevel_grp div.align-items-center,
+.path-mod-studentquiz #fgroup_id_publiccomment_grp div.align-items-center,
+.path-mod-studentquiz #fgroup_id_myrate_grp div.align-items-center,
+.path-mod-studentquiz #fgroup_id_myattempts_grp div.align-items-center,
+.path-mod-studentquiz #fgroup_id_mydifficulty_grp div.align-items-center {
+    /* stylelint-disable-next-line declaration-no-important */
+    align-items: flex-start !important;
 }


### PR DESCRIPTION
Hi Tim,

I have created the commit to change the approach CSS in form-group filter.
As I have discussed with you, we have no choices in the situation so I have set CSS important but it makes the cibot warning. I think we ignore the cibot warning in this case.

Could you please help me to review it?
Thanks

![image](https://user-images.githubusercontent.com/32395146/163513103-55b2994b-21ba-446d-bcdd-9c95522da231.png)
