### PR TITLE
StudentQuiz: Linebreaks in comments are not correctly displayed

### DIFF
--- a/classes/commentarea/comment.php
+++ b/classes/commentarea/comment.php
@@ -30,10 +30,7 @@ use popup_action;
 class comment {
 
     /** @var int - Shorten text with maximum length. */
-    const SHORTEN_LENGTH = 160;
-
-    /** @var string - Allowable tags when shorten text. */
-    const ALLOWABLE_TAGS = '<img>';
+    const SHORTEN_LENGTH = 75;
 
     /** @var string - Link to page when user press report button. */
     const ABUSE_PAGE = '/mod/studentquiz/reportcomment.php';
@@ -389,12 +386,13 @@ class comment {
         $comment = $this->data;
         $container = $this->get_container();
         $canviewdeleted = $container->can_view_deleted();
+        $stripped = utils::html_to_text($comment->comment);
         $object = new \stdClass();
         $object->id = $comment->id;
         $object->questionid = $comment->questionid;
         $object->parentid = $comment->parentid;
         $object->content = $comment->comment;
-        $object->shortcontent = utils::nice_shorten_text(strip_tags($comment->comment, self::ALLOWABLE_TAGS), self::SHORTEN_LENGTH);
+        $object->shortcontent = utils::nice_shorten_text($stripped, self::SHORTEN_LENGTH);
         $object->numberofreply = $this->get_total_replies();
         $object->plural = $this->get_reply_plural_text($object);
         $object->candelete = $this->can_delete();

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -114,16 +114,41 @@ style5 = html';
      * @return string
      */
     public static function nice_shorten_text($text, $length = 40) {
+        $text = htmlentities($text, null, 'utf-8');
+        $text = str_replace('&nbsp;', ' ', $text);
+        $text = html_entity_decode($text);
         $text = trim($text);
         // Replace image tag by placeholder text.
-        $text = preg_replace('/<img.*?>/', get_string('image_placeholder', 'mod_studentquiz'), $text);
-        $text = mb_convert_encoding($text, "HTML-ENTITIES", "UTF-8");
+        $text = preg_replace('/<img.*?>/', get_string('image_placeholder', 'studentquiz'), $text);
         // Trim the multiple spaces to single space and multiple lines to one line.
         $text = preg_replace('!\s+!', ' ', $text);
         $summary = shorten_text($text, $length);
         $summary = preg_replace('~\s*\.\.\.(<[^>]*>)*$~', '$1', $summary);
         $dots = $summary != $text ? '...' : '';
         return $summary . $dots;
+    }
+
+    /**
+     * Convert html format to plaintext with single line.
+     * @param string $content
+     * @return string
+     */
+    public static function html_to_text(string $content): string {
+        // Convert &nbsp; to space so we can trim multiple space.
+        $content = htmlentities($content, null, 'utf-8');
+        $content = str_replace('&nbsp;', ' ', $content);
+        $content = html_entity_decode($content);
+        // Only add spacing after block tags or end line tag.
+        $blocktags = ['address', 'article', 'aside', 'audio', 'blockquote', 'canvas', 'dd', 'div', 'dl', 'fieldset', 'figcaption',
+            'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'noscript', 'ol',
+            'output', 'p', 'pre', 'section', 'table', 'tfoot', 'ul', 'video', 'br', 'li'];
+        $regexptags = implode('|', $blocktags);
+        $text = preg_replace('/(<(?:\/){0,1}(?:' . $regexptags . ')[^>]*(?:\/)?>)/i', '$1 ', $content);
+        $text = strip_tags(
+            preg_replace('~<script.*?</script>~s', '', $text), '<img><del>');
+        // Remove multiple spaces.
+        $text = trim(preg_replace('/\s+/i', ' ', $text));
+        return $text;
     }
 
     /**

--- a/tests/utils_test.php
+++ b/tests/utils_test.php
@@ -100,4 +100,113 @@ class utils_test extends \advanced_testcase {
         $sink->close();
     }
 
+    /**
+     * Test replace html tags.
+     *
+     * @dataProvider remove_html_tag_provider
+     *
+     * @covers ::html_to_text
+     * @param string $result The data to test
+     * @param string $expected The expected result
+     */
+    public function test_remove_html_tag(string $result, string $expected) {
+        $result = utils::html_to_text($result);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for test_remove_html_tag.
+     *
+     * @return array
+     */
+    public function remove_html_tag_provider(): array {
+        return [
+            'Normal html tags' => [
+                "<p>String</p>with html<br /> tag",
+                "String with html tag"
+            ],
+            'Orderedlist and paragraph tags' => [
+                "<p>paragraph 1</p><ul><li>item 1</li><li>item 2</li></ul><p>paragraph 2</p>".
+                "<ol><li>item 1</li><li>item 2</li></ol>",
+                "paragraph 1 item 1 item 2 paragraph 2 item 1 item 2"
+            ],
+            'Orderedlist with multi level' => [
+                "<p>paragraph 1</p><ol><li>item 1<ol><li>subitem 1</li>".
+                "<li>subitem 2<ol><li>sub subitem 1</li><li>sub subitem 2</li></ol></li></ol></li>".
+                "<li>item 2</li></ol><p>paragraph 2</p><ul><li>item 1</li><li>item 2</li></ul>",
+                "paragraph 1 item 1 subitem 1 subitem 2 sub subitem 1 sub subitem 2 item 2 paragraph 2 item 1 item 2"
+            ],
+            'Heading tags' => [
+                "<h1>heading 1</h1><h2>heading 2</h2><h3>heading 3</h3><h4>heading 4</h4>".
+                "<h5>heading 5</h5><h6>heading 6</h6><p>paragraph 1</p><br /><p>paragraph 2</p>",
+                "heading 1 heading 2 heading 3 heading 4 heading 5 heading 6 paragraph 1 paragraph 2"
+            ],
+            'Content with img tag' => [
+                "a picture <img src='https://example.com/bg.jpg' />",
+                "a picture <img src='https://example.com/bg.jpg' />"
+            ],
+            'Mixed content' => [
+                "<h1>heading 1</h1><h2>heading 2</h2>with a picture ".
+                "<img src='https://example.com/bg.jpg' /><br /> and<p>paragraph 1</p>",
+                "heading 1 heading 2 with a picture <img src='https://example.com/bg.jpg' /> and paragraph 1"
+            ]
+        ];
+    }
+
+    /**
+     * Test replace html tags.
+     *
+     * @dataProvider nice_shorten_text_provider
+     *
+     * @covers ::nice_shorten_text
+     * @param array $result The data to test
+     * @param string $expected The expected result
+     */
+    public function test_nice_shorten_text(array $result, string $expected) {
+        [$text, $length] = $result;
+        $result = utils::nice_shorten_text($text, $length);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for test_remove_html_tag.
+     *
+     * @return array
+     */
+    public function nice_shorten_text_provider(): array {
+        return [
+            'Normal text already short enough' => [
+                ["This is the normal text", 40],
+                "This is the normal text"
+            ],
+            'Normal text needs shortening' => [
+                ["This is the normal text", 20],
+                "This is the..."
+            ],
+            'Line break text already short enough' => [
+                [
+                    "This is the normal text
+                    with line break",
+                    40
+                ],
+                "This is the normal text with line break"
+            ],
+            'Line break text needs shortening' => [
+                [
+                    "This is the normal text
+                    with line break",
+                    20
+                ],
+                "This is the..."
+            ],
+            'Normal text with image tag already short enough' => [
+                ["<img src='sample.png' alt='Sample Image'> This is simple text", 40],
+                " [Image] This is simple text"
+            ],
+            'Normal text with image tag needs shortening' => [
+                ["<img src='sample.png' alt='Sample Image'> This is simple text", 20],
+                " [Image] This is..."
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
Hi @timhunt ,
  In this commit, I have fixed the issue: 
  Add the space between lines when collapsing the comment.
Step to reproduce:
1. Create a StudentQuiz
2. Add a question (e.g., T/F)
3. Click on Start Quiz, attempt the question
4. In the comment section, add a comment with a few line breaks in between.
5. Collapse the comment

Actual result: When collapsed, the whitespace between lines is also missing.
![image](https://user-images.githubusercontent.com/31382675/172131917-6f856762-056b-4031-b0f8-ab81ab27709b.png)

Expected result: The space should exist to divide the lines when collapsing the comment.
![image](https://user-images.githubusercontent.com/31382675/172132431-43096c66-b2f2-4871-918c-837ac57917ae.png)


