### PR TITLE
StudentQuiz: Fix shorten text in comment to display correctly.

### DIFF
--- a/classes/commentarea/comment.php
+++ b/classes/commentarea/comment.php
@@ -30,7 +30,7 @@ use popup_action;
 class comment {
 
     /** @var int - Shorten text with maximum length. */
-    const SHORTEN_LENGTH = 160;
+    const SHORTEN_LENGTH = 75;
 
     /** @var string - Allowable tags when shorten text. */
     const ALLOWABLE_TAGS = '<img>';
@@ -394,7 +394,10 @@ class comment {
         $object->questionid = $comment->questionid;
         $object->parentid = $comment->parentid;
         $object->content = $comment->comment;
-        $object->shortcontent = utils::nice_shorten_text(strip_tags($comment->comment, self::ALLOWABLE_TAGS), self::SHORTEN_LENGTH);
+        // Convert the html content to text and treat the html in the content as normal text.
+        // Example : Loren isum <br> sample tag <p>.
+        $object->shortcontent = htmlspecialchars(html_to_text($comment->comment, 75, false));
+        $object->shortcontent = shorten_text($object->shortcontent, self::SHORTEN_LENGTH, false, '...');
         $object->numberofreply = $this->get_total_replies();
         $object->plural = $this->get_reply_plural_text($object);
         $object->candelete = $this->can_delete();

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -107,26 +107,6 @@ style5 = html';
     }
 
     /**
-     * Truncate text.
-     *
-     * @param string $text - Full text.
-     * @param int $length - Max length of text.
-     * @return string
-     */
-    public static function nice_shorten_text($text, $length = 40) {
-        $text = trim($text);
-        // Replace image tag by placeholder text.
-        $text = preg_replace('/<img.*?>/', get_string('image_placeholder', 'mod_studentquiz'), $text);
-        $text = mb_convert_encoding($text, "HTML-ENTITIES", "UTF-8");
-        // Trim the multiple spaces to single space and multiple lines to one line.
-        $text = preg_replace('!\s+!', ' ', $text);
-        $summary = shorten_text($text, $length);
-        $summary = preg_replace('~\s*\.\.\.(<[^>]*>)*$~', '$1', $summary);
-        $dots = $summary != $text ? '...' : '';
-        return $summary . $dots;
-    }
-
-    /**
      * Get data need for comment area.
      *
      * @param int $questionid - Question ID.

--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -185,7 +185,6 @@ $string['filter_label_tags'] = 'Tag';
 $string['finish_button'] = 'Finish';
 $string['history'] = 'History';
 $string['hidden'] = 'Hidden';
-$string['image_placeholder'] = ' [Image] ';
 $string['includingunread'] = ' (including unread)';
 $string['invalidcomment'] = 'invalidcomment';
 $string['invalidemail'] = 'This email address is not valid. Please enter a single email address.';

--- a/tests/behat/comment_area_create.feature
+++ b/tests/behat/comment_area_create.feature
@@ -160,6 +160,17 @@ Feature: Create comment as an user
     And I should see "Reply" in the ".studentquiz-comment-item:nth-child(1) .studentquiz-comment-totalreply" "css_element"
 
   @javascript
+  Scenario: Test reply comment with long content
+    When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I click on "Start Quiz" "button"
+    And I set the field "True" to "1"
+    And I press "Check"
+    And I enter the text "Comment 1 with long content: simply dummy text of the printing and typesetting industry." into the "Add public comment" editor
+    And I press "Add comment"
+    And I press "Collapse all comments"
+    Then I should see "Comment 1 with long content: simply dummy text of the printing ..."
+
+  @javascript
   Scenario: Test delete comment feature.
     # Save document into course 1.
     When I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"

--- a/tests/comment_test.php
+++ b/tests/comment_test.php
@@ -229,6 +229,18 @@ class comment_test extends \advanced_testcase {
     }
 
     /**
+     * Test create comment with long content and multiple line.
+     * @covers \comment::create_comment
+     */
+    public function test_create_comment_with_multiple_line() {
+        $q1 = $this->questions[0];
+        $text = '<p>Root comment with multiple line content</p><p>Line 2</p><p>Line 3</p><p>Line 4: simply dummy text of the.</p>';
+        $comment = $this->create_comment($this->rootid, $q1->id, $text, true);
+        $this->assertEquals(comment::SHORTEN_LENGTH, strlen($comment->shortcontent));
+        $this->assertStringContainsString('simply ...', $comment->shortcontent);
+    }
+
+    /**
      * Test delete comment.
      */
     public function test_delete_comment() {


### PR DESCRIPTION
Hi Tim,
I have removed the custom shorten text in SQ and using the core function.

Could you please help me to peer-review again?