### PR TITLE
StudentQuiz: page size setting is forgotten if you edit a question

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -49,6 +49,8 @@ require_login($cm->course, false, $cm);
 
 $attemptid = required_param('id', PARAM_INT);
 $slot = required_param('slot', PARAM_INT);
+$returnurl = optional_param('returnurl', '', PARAM_LOCALURL);
+
 $attempt = $DB->get_record('studentquiz_attempt', array('id' => $attemptid));
 
 $context = context_module::instance($cm->id);
@@ -75,11 +77,10 @@ if (!in_array($slot, $slots)) {
         $DB->update_record('studentquiz_attempt', $attempt);
     }
 }
-
-$actionurl = new moodle_url('/mod/studentquiz/attempt.php', array('cmid' => $cmid, 'id' => $attemptid, 'slot' => $slot));
+$actionurl = new moodle_url('/mod/studentquiz/attempt.php', ['cmid' => $cmid, 'id' =>
+    $attemptid, 'slot' => $slot, 'returnurl' => $returnurl]);
+$returnurl = $returnurl ? new moodle_url($returnurl) : new moodle_url('/mod/studentquiz/view.php', ['id' => $cmid]);
 // Reroute this to attempt summary page if desired.
-$stopurl = new moodle_url('/mod/studentquiz/view.php', array('id' => $cmid));
-
 // Get Current Question.
 $question = $questionusage->get_question($slot);
 // Navigatable?
@@ -149,7 +150,7 @@ if (data_submitted()) {
             $actionurl = new moodle_url($actionurl, array('slot' => $slot + 1));
             redirect($actionurl);
         } else {
-            redirect($stopurl);
+            redirect($returnurl);
         }
     } else if (optional_param('previous', null, PARAM_BOOL)) {
         if ($hasprevious) {
@@ -160,7 +161,7 @@ if (data_submitted()) {
             redirect($actionurl);
         }
     } else if (optional_param('finish', null, PARAM_BOOL)) {
-        redirect($stopurl);
+        redirect($returnurl);
     } else {
         redirect($actionurl);
     }

--- a/classes/question/bank/question_bank_filter.php
+++ b/classes/question/bank/question_bank_filter.php
@@ -97,9 +97,12 @@ class mod_studentquiz_question_bank_filter_form extends moodleform {
         $group[] = $mform->createElement('submit', 'submitbutton', get_string('filter'));
         $group[] = $mform->createElement('submit', 'resetbutton', get_string('reset'));
         $mform->addGroup($group, 'buttons', '', ' ', false);
-
         $mform->addElement('hidden', 'cmid', $this->_customdata['cmid']);
         $mform->setType('cmid', PARAM_RAW);
+        if (!empty($this->_customdata['qperpage'])) {
+            $mform->addElement('hidden', 'qperpage', $this->_customdata['qperpage']);
+            $mform->setType('qperpage', PARAM_INT);
+        }
     }
 
 }

--- a/renderer.php
+++ b/renderer.php
@@ -1360,6 +1360,11 @@ EOT;
                         'value' => $perpage,
                         'class' => 'form-control'
                     ]);
+                    $selectionperpage .= \html_writer::empty_tag('input', [
+                        'type' => 'hidden',
+                        'name' => 'changepagesize',
+                        'value' => 1,
+                    ]);
                     $pagingbaroutput .= \html_writer::div($selectionperpage, 'pull-right form-inline pagination m-t-1');
                 }
                 $pagingbaroutput .= $this->output->render($pagingbar);
@@ -1387,16 +1392,16 @@ EOT;
      * Generate hidden fields for Questions table form.
      *
      * @param int $cmid
-     * @param array $filterquestionids
      * @param moodle_url $baseurl
+     * @param int $perpage
      * @return string
      */
-    public function render_hidden_field($cmid, $filterquestionids, $baseurl) {
+    public function render_hidden_field(int $cmid, moodle_url $baseurl, int $perpage): string {
         $output = '';
 
         $output .= $this->generate_hidden_input('sesskey', sesskey());
         $output .= $this->generate_hidden_input('id', $cmid);
-        $output .= $this->generate_hidden_input('filtered_question_ids', implode(',', $filterquestionids));
+        $output .= $this->generate_hidden_input('qperpage', $perpage);
 
         $output .= \html_writer::input_hidden_params($baseurl, ['qperpage']);
 

--- a/tests/behat/pagination.feature
+++ b/tests/behat/pagination.feature
@@ -51,3 +51,50 @@ Feature: Test pagination for StudentQuiz
     And I should see "Test question 2"
     And I should not see "Test question 1"
     And I should not see "Test question 3"
+
+  @javascript
+  Scenario: Users edit question should keep the same pagination.
+    Given I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I set the field "qperpage" to "25"
+    And I press enter
+    And I choose "Edit question" action for "Test question 5" in the question bank
+    And I press "id_submitbutton"
+    Then "input[name='changepagesize']" "css_element" should not exist
+    And I should see "Test question 24"
+
+  @javascript
+  Scenario: Users create question should keep the same pagination.
+    Given I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I set the field "qperpage" to "25"
+    And I press enter
+    And I click on "Create new question" "button"
+    And I set the field "item_qtype_truefalse" to "1"
+    And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
+    And I set the field "Question name" to "TF 01"
+    And I set the field "Question text" to "The correct answer is false"
+    And I press "id_submitbutton"
+    Then "input[name='changepagesize']" "css_element" should not exist
+    And I should see "TF 01"
+    And I should see "Test question 24"
+
+  @javascript
+  Scenario: Users using filter should keep the same pagination.
+    Given I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I set the field "qperpage" to "25"
+    And I press enter
+    And I click on "New" "link"
+    And I press "id_submitbutton"
+    Then "input[name='changepagesize']" "css_element" should not exist
+    And I should see "Test question 24"
+
+  @javascript
+  Scenario: Users using start quiz button should keep the same pagination.
+    Given I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "admin"
+    And I set the field "qperpage" to "25"
+    And I press enter
+    And I click on "#qbheadercheckbox" "css_element"
+    And I click on "tr.r0 > td" "css_element" in the "Test question 1" "table_row"
+    And I click on "Start Quiz" "button"
+    And I press "Abort"
+    Then "input[name='changepagesize']" "css_element" should not exist
+    And I should see "Test question 24"


### PR DESCRIPTION
Hi Tim,
I have used the base_url to make all the actions in StudentQuiz question bank view have consistent behavior.
Most of logic is handle the base_url is in load_questionbank function.
Also, I have removed some the unused param like get_filtered_question_ids.
I have added changepagesize input because when we have an url like with query params like  cmid=1&qperpage=25 and don't have sesskey, it will cause an error.

Could you please take a look at this approach and peer-review it.

Man thanks