### PR TITLE
Fix incorrect syntax error

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -493,7 +493,8 @@ function mod_studentquiz_question_pluginfile($course, $context, $component,
     $fs = get_file_storage();
     $relativepath = implode('/', $args);
     $fullpath = "/$context->id/$component/$filearea/$relativepath";
-    if (!$file = $fs->get_file_by_hash(sha1($fullpath)) || $file->is_directory()) {
+    $file = $fs->get_file_by_hash(sha1($fullpath));
+    if (!$file || $file->is_directory()) {
         send_file_not_found();
     }
 


### PR DESCRIPTION
Hi @timhunt ,
Look like I make a mistake when I fix code checker error(change or to ||).
|| does not allow to using the same variable for two side but OR allow it.
Could you please help me to review the changes?

Many thanks