### PR TITLE
Broken images when quiz is launched

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -500,7 +500,8 @@ function mod_studentquiz_question_pluginfile($course, $context, $component,
     $fs = get_file_storage();
     $relativepath = implode('/', $args);
     $fullpath = "/$context->id/$component/$filearea/$relativepath";
-    if (!$file = $fs->get_file_by_hash(sha1($fullpath)) || $file->is_directory()) {
+    $file = $fs->get_file_by_hash(sha1($fullpath));
+    if (!$file || $file->is_directory()) {
         send_file_not_found();
     }
 


### PR DESCRIPTION
Hi,

On Moodle 3.9, added images work normally when we add them in text editor and when we preview them.
However, when we start quiz, they do not appear.

This is fixed in main branch (https://github.com/studentquiz/moodle-mod_studentquiz/commit/7af298d82a5dd3d487caed80c50039f29e5b5662), but can it be fixed in 3.x branche too ?