### PR TITLE
The recipient name and the actor names are flipped in anonymous ranki…

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -280,7 +280,7 @@ function mod_studentquiz_prepare_notify_data($studentquizquestion, $recepient, $
 
     // Set to anonymous student and manager if needed.
     $context = \context_course::instance($course->id);
-    $isstudent = !is_enrolled($context, $recepient->id, 'mod/studentquiz:manage');
+    $isstudent = is_enrolled($context, $recepient->id) && !has_capability('mod/studentquiz:manage', $context, $recepient->id);
     $data->isstudent = $isstudent;
     if ($studentquiz->anonymrank) {
         $anonymousstudent = get_string('creator_anonym_fullname', 'studentquiz');


### PR DESCRIPTION
Hi @timhunt ,
I have updated the old logic to make sure we are not missing the case where the user is not enrolled in the course but has manager permission in the course (for example users like admin).
I have added a unit test for this case as well.
I can't write the provider function because we need data from the setUp.

Could you please review the changes?