### PR TITLE
Create new renderer function for warning message

### DIFF
--- a/classes/question/bank/studentquiz_bank_view.php
+++ b/classes/question/bank/studentquiz_bank_view.php
@@ -362,7 +362,7 @@ class studentquiz_bank_view extends \core_question\local\bank\view {
                 $output .= $this->renderer->render_availability_message($message, 'mod_studentquiz_submission_info');
             }
         } else {
-            $output .= get_string('nopermissionadd', 'question');
+            $output .= $this->renderer->render_warning_message(get_string('nopermissionadd', 'question'));
         }
         echo $output;
     }

--- a/renderer.php
+++ b/renderer.php
@@ -1435,6 +1435,19 @@ EOT;
     }
 
     /**
+     * Render warning message when we don't have permission to add question.
+     *
+     * @param string $message warning message you want to display.
+     * @return string HTML string
+     */
+    public function render_warning_message(string $message): string {
+        $output = \html_writer::start_div('mod_studenquiz_warning');
+        $output .= $message;
+        $output .= \html_writer::end_div();
+        return $output;
+    }
+
+    /**
      * Render current state names of questions.
      *
      * @param array $questions List of questions.


### PR DESCRIPTION
Hi @timhunt ,
When I try this the defect related to this 619311 on our OSEP theme.
I found out we can't style the warning message directly since they really don't have a wrapper div. We can't style it without affecting other elements.
So I add a wrapper and move it to the renderer so we can easily customize it.

![Capture](https://user-images.githubusercontent.com/42837030/200458244-30e2562e-1050-41ba-80e1-462fb69a1fbb.PNG)

Does it make sense?

