### PR TITLE
StudentQuiz: Student can view and attempt the questions that belong t…

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -205,7 +205,7 @@ $navinfo->current = $slot;
 $navinfo->total = $questionscount;
 $PAGE->navbar->add(get_string('nav_question_no', 'studentquiz', $navinfo));
 
-utils::require_access_to_a_relevant_group($cm, $context);
+utils::require_access_to_a_relevant_group($cm, $context, '', $studentquizquestion);
 
 echo $OUTPUT->header();
 

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -773,14 +773,21 @@ style5 = html';
      * @param object $cm - The course module object.
      * @param \context $context The context module.
      * @param string $title Page's title.
+     * @param studentquiz_question|null $studentquizquestion Student quiz question object.
      * @return void
      */
-    public static function require_access_to_a_relevant_group(object $cm, \context $context, string $title = ''): void {
-        global $COURSE, $PAGE;
-        $groupmode = (int)groups_get_activity_groupmode($cm, $COURSE);
+    public static function require_access_to_a_relevant_group(object $cm, \context $context, string $title = '',
+            studentquiz_question $studentquizquestion = null): void {
+        global $COURSE, $PAGE, $USER;
+        $groupmode = (int) groups_get_activity_groupmode($cm, $COURSE);
         $currentgroup = groups_get_activity_group($cm, true);
+        $isallowaccessgroup = ($studentquizquestion === null) ||
+            groups_group_visible($studentquizquestion->get_groupid(), $COURSE, $cm, $USER->id);
 
-        if ($groupmode === SEPARATEGROUPS && !$currentgroup && !has_capability('moodle/site:accessallgroups', $context)) {
+        if ($groupmode === SEPARATEGROUPS && !has_capability('moodle/site:accessallgroups', $context) &&
+                (!$currentgroup || !$isallowaccessgroup)) {
+            // If the student quiz in separate groups mode and
+            // the user does not belong to the question group, an error message will be displayed.
             $renderer = $PAGE->get_renderer('mod_studentquiz');
             $renderer->render_error_message(get_string('error_permission', 'studentquiz'), $title);
             exit();


### PR DESCRIPTION
Hi @timhunt ,

I have resolved this ticket by updating the function `require_access_to_a_relevant_group`. After spending time investigating this issue, I realized that the function `require_access_to_a_relevant_group` only covers cases where the user doesn't have the current group and tries to access the student quiz with the group mode set to separate groups.

However, in situations where the user has another group that does not belong to the valid group, this function does not handle it properly. Therefore, I believe it's necessary to update this function to address this scenario.

Regarding the use of `exit()` in this function, it makes it challenging to write unit tests for it when it always stop the code flow, so that I can't write Unite test for it.
Commit ID: [4cbcd6d8b267e83f7ff29616fa2df3a08aeb0d94](https://github.com/studentquiz/moodle-mod_studentquiz/pull/459/commits/4cbcd6d8b267e83f7ff29616fa2df3a08aeb0d94)
I'd appreciate your feedback on my changes. Please let me know your thoughts. Thank you.