### PR TITLE
StudentQuiz: Warning message is displayed when student views the comm…

### DIFF
--- a/classes/commentarea/container.php
+++ b/classes/commentarea/container.php
@@ -927,7 +927,7 @@ class container {
                     $instance->authorname = get_string('anonymous_user_name', 'mod_studentquiz', $instance->rownumber);
                 }
                 $userinfocacheset[$commenthistory->userid] = $instance->authorname;
-                $profileurl[$commenthistory->userid] = $instance->authorprofileurl;
+                $profileurl[$commenthistory->userid] = $instance->authorprofileurl ?? '';
             } else {
                 $instance->authorname = $userinfocacheset[$commenthistory->userid];
                 $instance->authorprofileurl = $profileurl[$commenthistory->userid];


### PR DESCRIPTION
…ent history #703301

Hi @timhunt,
The issue occurred when the $instance->authorprofileurl is null. I have added the 'Null coalescing operator' to handle the case when $instance->authorprofileurl is null. This ticket is now ready for review.
Could you please review this change? Many thanks.