### PR TITLE
StudentQuiz: add completion criteria #604186

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -63,7 +63,7 @@ $context = context_module::instance($cm->id);
 
 $studentquiz = mod_studentquiz_load_studentquiz($cmid, $context->id);
 
-global $USER;
+global $USER, $COURSE;
 $userid = $USER->id;
 
 $questionusage = question_engine::load_questions_usage_by_activity($attempt->questionusageid);
@@ -147,6 +147,8 @@ if (data_submitted()) {
     }
 
     $transaction->allow_commit();
+    // Update completion state.
+    \mod_studentquiz\completion\custom_completion::update_state($COURSE, $cm);
 
     // Navigate accordingly. If no navigation button has been submitted, then there has been a question answer attempt.
     if (optional_param('next', null, PARAM_BOOL)) {

--- a/backup/moodle2/backup_studentquiz_stepslib.php
+++ b/backup/moodle2/backup_studentquiz_stepslib.php
@@ -42,7 +42,7 @@ class backup_studentquiz_activity_structure_step extends backup_questions_activi
                 'allowedqtypes', 'aggregated', 'excluderoles', 'forcerating', 'forcecommenting',
                 'commentdeletionperiod', 'reportingemail', 'digesttype', 'digestfirstday', 'privatecommenting',
                 'opensubmissionfrom', 'closesubmissionfrom', 'openansweringfrom', 'closeansweringfrom',
-                'publishnewquestion'
+                'publishnewquestion', 'completionpoint', 'completionquestionpublished', 'completionquestionapproved'
         ]);
 
         // StudentQuiz Attempt -> User, Question usage Id.

--- a/classes/completion/custom_completion.php
+++ b/classes/completion/custom_completion.php
@@ -1,0 +1,131 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+declare(strict_types=1);
+
+namespace mod_studentquiz\completion;
+
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/../../reportlib.php');
+
+use core_completion\activity_custom_completion;
+use mod_studentquiz_report;
+use cm_info;
+use stdClass;
+
+/**
+ * Activity custom completion subclass for the data activity.
+ *
+ * Class for defining mod_studentquiz's custom completion rules and fetching the completion statuses
+ * of the custom completion rules for a given data instance and a user.
+ *
+ * @package mod_studentquiz
+ * @copyright 2023 The Open University
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class custom_completion extends activity_custom_completion {
+    /**
+     * Fetches the completion state for a given completion rule.
+     *
+     * @param string $rule The completion rule.
+     * @return int The completion state.
+     */
+    public function get_state(string $rule): int {
+        global $DB;
+        $studentquizid = $this->cm->instance;
+        if (!$studentquiz = $DB->get_record('studentquiz', ['id' => $studentquizid])) {
+            throw new \moodle_exception('Unable to find studentquiz with id ' . $studentquizid);
+        }
+        $report = new mod_studentquiz_report($this->cm->id, $this->userid);
+        $userstats = $report->get_user_stats();
+        switch ($rule) {
+            case 'completionpoint':
+                $status = $studentquiz->completionpoint <= (int) $userstats->points;
+                break;
+            case 'completionquestionpublished':
+                $status = $studentquiz->completionquestionpublished <= (int) $userstats->questions_created;
+                break;
+            case 'completionquestionapproved':
+                $status = $studentquiz->completionquestionapproved <= (int) $userstats->questions_approved;
+                break;
+            default:
+                $status = COMPLETION_INCOMPLETE;
+                break;
+        }
+
+        return $status ? COMPLETION_COMPLETE : COMPLETION_INCOMPLETE;
+    }
+
+    /**
+     * Fetch the list of custom completion rules that this module defines.
+     *
+     * @return array An array of custom completion rules.
+     */
+    public static function get_defined_custom_rules(): array {
+        return [
+            'completionpoint',
+            'completionquestionpublished',
+            'completionquestionapproved',
+        ];
+    }
+
+    /**
+     * Returns an associative array of the descriptions of custom completion rules.
+     *
+     * @return array An array of custom completion rules description.
+     */
+    public function get_custom_rule_descriptions(): array {
+        $completionpoint = $this->cm->customdata->customcompletionrules['completionpoint'] ?? 0;
+        $completionquestionpublished = $this->cm->customdata->customcompletionrules['completionquestionpublished'] ?? 0;
+        $completionquestionapproved = $this->cm->customdata->customcompletionrules['completionquestionapproved'] ?? 0;
+
+        return [
+            'completionpoint' => get_string('completiondetail:point', 'studentquiz', $completionpoint),
+            'completionquestionpublished' => get_string('completiondetail:published', 'studentquiz',
+                $completionquestionpublished),
+            'completionquestionapproved' => get_string('completiondetail:approved',
+                'studentquiz', $completionquestionapproved),
+        ];
+    }
+
+    /**
+     * Returns an array of all completion rules, in the order they should be displayed to users.
+     *
+     * @return array An array of all completion rules.
+     */
+    public function get_sort_order(): array {
+        $defaults = [
+           'completionview',
+        ];
+
+        return array_merge($defaults, self::get_defined_custom_rules());
+    }
+
+
+    /**
+     * Update state for the completion.
+     *
+     * @param stdClass $course The course object.
+     * @param stdClass|cm_info $cm Course module.
+     * @param int|null $userid Id of user creating the question.
+     */
+    public static function update_state(stdClass $course, $cm, ?int $userid = null): void {
+        $completion = new \completion_info($course);
+        if ($completion->is_enabled($cm)) {
+            $completion->update_state($cm, COMPLETION_UNKNOWN, $userid);
+        }
+    }
+
+}

--- a/classes/external/update_question_state.php
+++ b/classes/external/update_question_state.php
@@ -107,6 +107,10 @@ class update_question_state extends external_api {
             $statename = studentquiz_helper::$statename[$state];
             mod_studentquiz_event_notification_question($statename, $studentquizquestion, $course, $cm);
         }
+        $userid = $studentquizquestion->get_question()->createdby;
+        // Update completion state.
+        \mod_studentquiz\completion\custom_completion::update_state($course, $cm, $userid);
+
         $result = [];
         $result['status'] = get_string('api_state_change_success_title', 'studentquiz');
         $result['message'] = get_string('api_state_change_success_content', 'studentquiz');

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -33,8 +33,7 @@ class mod_studentquiz_observer {
      * @param \core\event\question_created $event
      */
     public static function question_created(\core\event\question_created $event) {
-        global $CFG;
-
+        global $CFG, $COURSE;
         require_once($CFG->dirroot . '/mod/studentquiz/locallib.php');
 
         if ($event->contextlevel == CONTEXT_MODULE) {
@@ -44,6 +43,8 @@ class mod_studentquiz_observer {
             if ($cm->modname == 'studentquiz') {
                 mod_studentquiz_ensure_studentquiz_question_record($event->objectid, $event->contextinstanceid);
                 utils::ensure_question_version_status_is_correct($event->objectid);
+                // Update completion state.
+                \mod_studentquiz\completion\custom_completion::update_state($COURSE, $cm);
             }
         }
     }

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/studentquiz/db" VERSION="20220810" COMMENT="mod_studentquiz database layout"
+<XMLDB PATH="mod/studentquiz/db" VERSION="20230727" COMMENT="mod_studentquiz database layout"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -36,6 +36,9 @@
         <FIELD NAME="digesttype" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Email digest type"/>
         <FIELD NAME="digestfirstday" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="First day of week"/>
         <FIELD NAME="privatecommenting" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Property if studentquiz is enable private discussions"/>
+        <FIELD NAME="completionpoint" TYPE="int" LENGTH="9" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Nonzero if a certain minimum amount of points required to mark this forum complete for a user."/>
+        <FIELD NAME="completionquestionpublished" TYPE="int" LENGTH="9" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Nonzero if a certain minimum number of unique authored questions required to mark this forum complete for a user."/>
+        <FIELD NAME="completionquestionapproved" TYPE="int" LENGTH="9" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Nonzero if a certain minimum number of unique approved questions required to mark this forum complete for a user."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1675,5 +1675,53 @@ function xmldb_studentquiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2023053000, 'studentquiz');
     }
 
+    if ($oldversion < 2023081700) {
+
+        // Define field completionpoint to be added to studentquiz.
+        $table = new xmldb_table('studentquiz');
+        $field = new xmldb_field('completionpoint', XMLDB_TYPE_INTEGER, '9', null, XMLDB_NOTNULL, null,
+            '0', 'privatecommenting');
+
+        // Conditionally launch add field completionpoint.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Studentquiz savepoint reached.
+        upgrade_mod_savepoint(true, 2023081700, 'studentquiz');
+    }
+
+    if ($oldversion < 2023081701) {
+
+        // Define field completionquestionpublished to be added to studentquiz.
+        $table = new xmldb_table('studentquiz');
+        $field = new xmldb_field('completionquestionpublished', XMLDB_TYPE_INTEGER, '9', null, XMLDB_NOTNULL, null,
+            '0', 'completionpoint');
+
+        // Conditionally launch add field completionquestionpublished.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Studentquiz savepoint reached.
+        upgrade_mod_savepoint(true, 2023081701, 'studentquiz');
+    }
+
+    if ($oldversion < 2023081702) {
+
+        // Define field completionquestionapproved to be added to studentquiz.
+        $table = new xmldb_table('studentquiz');
+        $field = new xmldb_field('completionquestionapproved', XMLDB_TYPE_INTEGER, '9', null, XMLDB_NOTNULL, null,
+            '0', 'completionquestionpublished');
+
+        // Conditionally launch add field completionquestionapproved.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Studentquiz savepoint reached.
+        upgrade_mod_savepoint(true, 2023081702, 'studentquiz');
+    }
+
     return true;
 }

--- a/lang/en/studentquiz.php
+++ b/lang/en/studentquiz.php
@@ -72,6 +72,21 @@ $string['commentcolumnexplainpublic'] = "Number of public comments. A blue backg
 $string['commentcolumnexplainprivate'] = "Number of private comments. A blue background means that you have at least one unread comment.";
 $string['commenthistory'] = 'Comment history';
 $string['comment_veryshort'] = 'C';
+$string['completiondetail:approved'] = 'Minimum number of unique approved questions: {$a}';
+$string['completiondetail:published'] = 'Minimum number of unique authored questions: {$a}';
+$string['completiondetail:point'] = 'Minimum amount of points: {$a}';
+
+$string['completionpoint'] = 'Minimum amount of points required:';
+$string['completionpointgroup'] = 'Require points';
+$string['completionpointgroup_help'] = 'Students earn points as specified under the Ranking settings, e.g. 10 points for creating a question, 5 points for a teacher approving the students\' question, 3 points for the student rating another\'s question. By entering a numeric value in the field, students will only complete the StudentQuiz once they have accumulated enough points.';
+
+$string['completionquestionapproved'] = 'Minimum number of unique approved questions required:';
+$string['completionquestionapprovedgroup'] = 'Require created approved questions';
+$string['completionquestionapprovedgroup_help'] = 'the minimum number of unique questions that a student must author and be approved before the activity is completed. This option can be used with either the Question publishing "Requires approval before publishing" or "Auto-approval" setting, but won\'t be as effective with the latter setting, in case auto-approved questions are later hidden, deleted, or otherwise removed.';
+
+$string['completionquestionpublished'] = 'Minimum number of unique authored questions required:';
+$string['completionquestionpublishedgroup'] = 'Require published questions';
+$string['completionquestionpublishedgroup_help'] = 'The minimum number of unique questions that a student must author before the activity is completed. Note that this is a simple numerical check - two questions that are hidden/deleted have still been authored.';
 $string['confirmdeletecomment'] = 'Are you sure you want to delete this comment?';
 $string['createnewquestion'] = 'Create new question';
 $string['createnewquestionfirst'] = 'Create first question';

--- a/mod_form.php
+++ b/mod_form.php
@@ -274,6 +274,89 @@ class mod_studentquiz_mod_form extends moodleform_mod {
                 $defaultvalues["excluderoles[$role]"] = (int)in_array($role, $enabled);
             }
         }
+        $defaultvalues['completionpointenabled'] = !empty($defaultvalues['completionpoint']) ? 1 : 0;
+        if (empty($defaultvalues['completionpoint'])) {
+            $defaultvalues['completionpoint'] = 1;
+        }
+        $defaultvalues['completionquestionpublishedenabled'] = !empty($defaultvalues['completionquestionpublished']) ? 1
+            : 0;
+        if (empty($defaultvalues['completionquestionpublished'])) {
+            $defaultvalues['completionquestionpublished'] = 1;
+        }
+        $defaultvalues['completionquestionapprovedenabled'] = !empty($defaultvalues['completionquestionapproved']) ? 1
+            : 0;
+        if (empty($defaultvalues['completionquestionapproved'])) {
+            $defaultvalues['completionquestionapproved'] = 1;
+        }
+    }
+
+    /**
+     * List of added element names, or names of wrapping group elements.
+     *
+     * @return array List of added element names, or names of wrapping group elements.
+     */
+    public function add_completion_rules(): array {
+        $mform =& $this->_form;
+
+        // Require point.
+        $group = [];
+        $group[] =& $mform->createElement('checkbox', 'completionpointenabled', '',
+            get_string('completionpoint', 'mod_studentquiz'));
+        $group[] =& $mform->createElement('text', 'completionpoint', '', ['size' => 3]);
+        $mform->setType('completionpoint', PARAM_INT);
+        $mform->addGroup($group, 'completionpointgroup', get_string('completionpointgroup',
+            'mod_studentquiz'), [' '], false);
+        $mform->addHelpButton('completionpointgroup', 'completionpointgroup',
+            'mod_studentquiz');
+        $mform->disabledIf('completionpoint', 'completionpointenabled', 'notchecked');
+
+        // Require published questions.
+        $group = [];
+        $group[] =& $mform->createElement('checkbox', 'completionquestionpublishedenabled', '',
+            get_string('completionquestionpublished', 'mod_studentquiz'));
+        $group[] =& $mform->createElement('text', 'completionquestionpublished', '',
+            ['size' => 3]);
+        $mform->setType('completionquestionpublished', PARAM_INT);
+        $mform->addGroup($group, 'completionquestionpublishedgroup',
+            get_string('completionquestionpublishedgroup', 'mod_studentquiz'),
+                [' '], false);
+        $mform->addHelpButton('completionquestionpublishedgroup',
+            'completionquestionpublishedgroup', 'mod_studentquiz');
+        $mform->disabledIf('completionquestionpublished', 'completionquestionpublishedenabled',
+            'notchecked');
+
+        // Require created approved questions.
+        $group = [];
+        $group[] =& $mform->createElement('checkbox',
+            'completionquestionapprovedenabled', '', get_string('completionquestionapproved',
+                'mod_studentquiz'));
+        $group[] =& $mform->createElement('text',
+            'completionquestionapproved', '', ['size' => 3]);
+        $mform->setType('completionquestionapproved', PARAM_INT);
+        $mform->addGroup($group, 'completionquestionapprovedgroup',
+            get_string('completionquestionapprovedgroup', 'mod_studentquiz'), [' '],
+            false);
+        $mform->addHelpButton('completionquestionapprovedgroup',
+            'completionquestionapprovedgroup', 'mod_studentquiz');
+        $mform->disabledIf('completionquestionapproved',
+            'completionquestionapprovedenabled', 'notchecked');
+
+        return ['completionpointgroup', 'completionquestionpublishedgroup', 'completionquestionapprovedgroup'];
+    }
+
+    /**
+     * Called during validation to see whether some activity-specific completion rules are selected.
+     *
+     * @param array $data Input data not yet validated.
+     * @return bool True if one or more rules is enabled, false if none are.
+     */
+    public function completion_rule_enabled($data): bool {
+        return (!empty($data['completionpointenabled'])
+            && $data['completionpoint'] != 0)
+            || (!empty($data['completionquestionpublishedenabled'])
+            && $data['completionquestionpublished'] != 0)
+            || (!empty($data['completionquestionapprovedenabled'])
+            && $data['completionquestionapproved'] != 0);
     }
 
     /**
@@ -336,6 +419,21 @@ class mod_studentquiz_mod_form extends moodleform_mod {
                 $data->reportingemail = null;
             }
         }
+
+        // Turn off completion settings if the checkboxes aren't ticked.
+        if (!empty($data->completionunlocked)) {
+            $autocompletion = !empty($data->completion) && $data->completion == COMPLETION_TRACKING_AUTOMATIC;
+            if (empty($data->completionpointenabled) || !$autocompletion) {
+                $data->completionpoint = 0;
+            }
+            if (empty($data->completionquestionpublishedenabled) || !$autocompletion) {
+                $data->completionquestionpublished = 0;
+            }
+            if (empty($data->completionquestionapprovedenabled) || !$autocompletion) {
+                $data->completionquestionapproved = 0;
+            }
+        }
+
         return $data;
     }
 

--- a/reportlib.php
+++ b/reportlib.php
@@ -168,9 +168,10 @@ class mod_studentquiz_report {
 
     /**
      * Constructor assuming we already have the necessary data loaded.
-     * @param int $cmid course_module id
+     * @param int|string $cmid course_module id
+     * @param int|null $userid user id.
      */
-    public function __construct($cmid) {
+    public function __construct($cmid, ?int $userid = null) {
         global $DB, $USER;
         if (!$this->cm = get_coursemodule_from_id('studentquiz', $cmid)) {
             throw new mod_studentquiz_view_exception($this, 'invalidcoursemodule');
@@ -187,6 +188,9 @@ class mod_studentquiz_report {
         $this->context = context_module::instance($this->cm->id);
 
         $this->userid = $USER->id;
+        if ($userid) {
+            $this->userid = $userid;
+        }
         $this->availablequestions = mod_studentquiz_count_questions($cmid);
 
         \mod_studentquiz\utils::set_default_group($this->cm);

--- a/save.php
+++ b/save.php
@@ -33,6 +33,8 @@ define('AJAX_SCRIPT', true);
 require_once(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/locallib.php');
 
+global $COURSE;
+
 // Get parameters.
 $cmid = optional_param('cmid', 0, PARAM_INT);
 $studentquizquestionid = required_param('studentquizquestionid', PARAM_INT);
@@ -70,5 +72,13 @@ switch($save) {
         mod_studentquiz\utils::save_rate($data);
         break;
 }
+$contextmodule = \context_module::instance($cmid);
+$cm = get_coursemodule_from_id('studentquiz', $cmid);
+$studentquiz = mod_studentquiz_load_studentquiz($cmid, $contextmodule->id);
+$studentquizquestion = new mod_studentquiz\local\studentquiz_question($studentquizquestionid, null,
+    $studentquiz);
+$userid = $studentquizquestion->get_question()->createdby;
+// Update completion state.
+\mod_studentquiz\completion\custom_completion::update_state($COURSE, $cm, $userid);
 
 header('Content-Type: text/html; charset=utf-8');

--- a/tests/behat/custom_completion.feature
+++ b/tests/behat/custom_completion.feature
@@ -1,0 +1,105 @@
+@mod @mod_studentquiz
+Feature: Set a studentquiz to be marked complete when the student meets the conditions of the completion
+  In order to ensure a student has completed the quiz before being marked complete
+  As a teacher
+  I will be able to see that studentquiz activity completed when the student completes
+
+  Background:
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Terry1    | Teacher1 | teacher1@example.com |
+      | student1 | student1  | Student1 | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | category | enablecompletion |
+      | Course 1 | C1        | 0        | 1                |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage with editing mode on
+
+  @javascript
+  Scenario: Check studentquiz mark done when the student meets the conditions of the completion point
+    Given I add a "StudentQuiz" to section "1"
+    When I set the following fields to these values:
+      | StudentQuiz Name       | StudentQuiz 1                |
+      | Description            | Test studentquiz description |
+      | completion             | 2                            |
+      | completionpointenabled | 1                            |
+      | completionpoint        | 10                           |
+    And I press "Save and display"
+    And I log out
+    # Create owned question by student role.
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    And I click on "Create new question" "button"
+    And I set the field "item_qtype_truefalse" to "1"
+    And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
+    And I should see "Adding a True/False question"
+    And I set the field "Question name" to "Example question 1"
+    And I set the field "Question text" to "The correct answer is true"
+    And I press "id_submitbutton"
+    Then the "Minimum amount of points: 10" completion condition of "StudentQuiz 1" is displayed as "done"
+
+  @javascript
+  Scenario: Check studentquiz mark done when the student meets the conditions of the completion created
+    Given I add a "StudentQuiz" to section "1"
+    When I set the following fields to these values:
+      | StudentQuiz Name                 | StudentQuiz 1                |
+      | Description                      | Test studentquiz description |
+      | completion                       | 2                            |
+      | completionquestionpublishedenabled | 1                            |
+      | completionquestionpublished        | 2                            |
+    And I press "Save and display"
+    And I log out
+    # Create owned question by student role.
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    And I click on "Create new question" "button"
+    And I set the field "item_qtype_truefalse" to "1"
+    And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
+    And I should see "Adding a True/False question"
+    And I set the field "Question name" to "Example question 1"
+    And I set the field "Question text" to "The correct answer is true"
+    And I press "id_submitbutton"
+    And the "Minimum number of unique authored questions: 2" completion condition of "StudentQuiz 1" is displayed as "todo"
+    And I click on "Create new question" "button"
+    And I set the field "item_qtype_truefalse" to "1"
+    And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
+    And I should see "Adding a True/False question"
+    And I set the field "Question name" to "Example question 2"
+    And I set the field "Question text" to "The correct answer is true"
+    And I press "id_submitbutton"
+    Then the "Minimum number of unique authored questions: 2" completion condition of "StudentQuiz 1" is displayed as "done"
+
+  @javascript
+  Scenario: Check studentquiz mark done when the student meets the conditions of the completion created approved
+    Given I add a "StudentQuiz" to section "1"
+    When I set the following fields to these values:
+      | StudentQuiz Name                  | StudentQuiz 1                |
+      | Description                       | Test studentquiz description |
+      | completion                        | 2                            |
+      | publishnewquestion                | 1                            |
+      | completionquestionapprovedenabled | 1                            |
+      | completionquestionapproved        | 1                            |
+    And I press "Save and display"
+    And I log out
+    # Create owned question by student role.
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    And I click on "Create new question" "button"
+    And I set the field "item_qtype_truefalse" to "1"
+    And I click on "Add" "button" in the "Choose a question type to add" "dialogue"
+    And I should see "Adding a True/False question"
+    And I set the field "Question name" to "Example question 1"
+    And I set the field "Question text" to "The correct answer is true"
+    And I press "id_submitbutton"
+    And I log out
+    # Teacher approve a question.
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "teacher1"
+    And I choose "Preview" action for "Example question 1" in the question bank
+    And I switch to "questionpreview" window
+    And I set the field "statetype" to "Approved"
+    And I click on "Change state" "button"
+    And I switch to the main window
+    And I log out
+    And I am on the "StudentQuiz 1" "mod_studentquiz > View" page logged in as "student1"
+    Then the "Minimum number of unique approved questions: 1" completion condition of "StudentQuiz 1" is displayed as "done"

--- a/tests/custom_completion_test.php
+++ b/tests/custom_completion_test.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_studentquiz;
+
+use advanced_testcase;
+use mod_studentquiz\completion\custom_completion;
+use cm_info;
+
+/**
+ * Class for unit testing mod_studentquiz/custom_completion.
+ *
+ * @package   mod_studentquiz
+ * @copyright 2023 The Open University
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @coversDefaultClass \mod_studentquiz\completion\custom_completion
+ */
+class custom_completion_test extends advanced_testcase {
+    /**
+     * Test for get_defined_custom_rules().
+     *
+     * @covers ::get_defined_custom_rules
+     */
+    public function test_get_defined_custom_rules(): void {
+        $rules = custom_completion::get_defined_custom_rules();
+        $this->assertCount(3, $rules);
+        $this->assertEquals(
+            ['completionpoint', 'completionquestionpublished', 'completionquestionapproved'],
+            $rules
+        );
+    }
+
+    /**
+     * Test for get_defined_custom_rule_descriptions().
+     *
+     * @covers ::get_custom_rule_descriptions
+     */
+    public function test_get_custom_rule_descriptions() {
+        // Get defined custom rules.
+        $rules = custom_completion::get_defined_custom_rules();
+
+        // Build a mock cm_info instance.
+        $mockcminfo = $this->getMockBuilder(cm_info::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__get'])
+            ->getMock();
+        // Instantiate a custom_completion object using the mocked cm_info.
+        $customcompletion = new custom_completion($mockcminfo, 1);
+
+        // Get custom rule descriptions.
+        $ruledescriptions = $customcompletion->get_custom_rule_descriptions();
+
+        // Confirm that defined rules and rule descriptions are consistent with each other.
+        $this->assertEquals(count($rules), count($ruledescriptions));
+        foreach ($rules as $rule) {
+            $this->assertArrayHasKey($rule, $ruledescriptions);
+        }
+    }
+
+}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023062200;
+$plugin->version = 2023081702;
 $plugin->requires = 2022041900; // Version MOODLE_4.0.
 $plugin->component = 'mod_studentquiz';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Hi @timhunt ,

I wanted to let you know about some recent updates to this ticket regarding completion criteria. The changes include the introduction of completion points, completion question publishing, and completion question approval.

Here's an overview of the steps I took to implement these changes:

1. I incorporated new fields into the database.
2. I enabled the features FEATURE_COMPLETION_HAS_RULES and FEATURE_COMPLETION_TRACK_VIEW.
3. I integrated the function studentquiz_get_coursemodule_info into lib.php.
4. Custom completion logic was introduced in classes/completion/custom_completion.php, mod_form.php, and lang/en/studentquiz.php.
5. I extended the state update not only for the current user but also for users impacted by the studentquiz points. This involved modifications to reportlib.php.
6. I ensured state updates for users in various scenarios:
   - Creating new questions (classes/observer.php)
   - Rating questions (save.php)
   - Attempting questions (attempt.php)
   - Changing question state (classes/external/update_question_state.php)
7. Additionally, I carried out testing for the custom completion using tests/custom_completion_test.php and tests/behat/custom_completion.feature.

I would greatly appreciate it if you could take a moment to review these changes. Many thanks.