### PR TITLE
StudentQuiz: Fix wrong param declaration

### DIFF
--- a/classes/local/external/get_comments_api.php
+++ b/classes/local/external/get_comments_api.php
@@ -57,7 +57,7 @@ class get_comments_api extends external_api {
                 'cmid' => new external_value(PARAM_INT, 'Cm ID'),
                 'numbertoshow' => new external_value(PARAM_INT, 'Number of comments to show, 0 will return all comments/replies',
                         VALUE_DEFAULT, container::NUMBER_COMMENT_TO_SHOW_BY_DEFAULT),
-                'sort' => new external_value(PARAM_TEXT, 'Sort type', false),
+                'sort' => new external_value(PARAM_TEXT, 'Sort type'),
                 'type' => new external_value(PARAM_INT, 'Comment type', VALUE_DEFAULT, utils::COMMENT_TYPE_PUBLIC)
         ]);
     }


### PR DESCRIPTION
Hi @timhunt ,
This change is to fix the wrong declaration of sort param that causing the warning in 724262
![image](https://github.com/studentquiz/moodle-mod_studentquiz/assets/42837030/a8d15caf-512b-4e99-b6b7-992cacd8f8b5)

So this issue is ready for review
